### PR TITLE
DAT-338 from https://github.com/GreaterLondonAuthority/Data_for_London/pull/48

### DIFF
--- a/ckanext/gla/templates/package/snippets/resource_item.html
+++ b/ckanext/gla/templates/package/snippets/resource_item.html
@@ -1,0 +1,18 @@
+{% ckan_extends %}
+{% block resource_item_title %}
+    <a class="heading" href="{{ res.url }}" title="{{ res.name or res.description }}">
+        {{ h.resource_display_name(res) | truncate(50) }}<span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ h.get_translated(res, 'format') }}</span>
+        {{ h.popular('views', res.tracking_summary.total, min=10) if res.tracking_summary }}
+    </a>
+{% endblock %}
+
+{% block resource_item_explore %}
+    {% if not url_is_edit %}
+        <div class="dropdown btn-group">
+            <a href="{{ url }}" class="btn btn-primary" type="button">
+                <i class="fa fa-info-circle"></i>
+                {{ _('More information') }}
+            </a>
+        </div>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
Created from https://github.com/GreaterLondonAuthority/Data_for_London/pull/48 by running

```
git format-patch --relative=src/ckanext-gla origin/develop --stdout > dat-338.mbox
```

in the main repository and then applying the patch to this repository with

```
git am ../../../Data_for_London-alt/dat-338.mbox
```