### PR TITLE
DAT-272 - Placeholder for privacy policy and deletion request

### DIFF
--- a/ckanext/gla/templates/footer.html
+++ b/ckanext/gla/templates/footer.html
@@ -9,7 +9,7 @@
                 <li><a href="#">Contact Us</a></li>
                 <li><a href="#">Governance</a></li>
                 <li><a href="#">Standards</a></li>
-                <li><a href="#">Privacy Policy</a></li>
+                <li><a href="/privacy-policy">Privacy Policy</a></li>
             </ul>
           {% endblock %}
         </div>

--- a/ckanext/gla/templates/privacy.html
+++ b/ckanext/gla/templates/privacy.html
@@ -1,0 +1,30 @@
+{% extends "page.html" %}
+
+
+{% block primary %}
+<article class="module" role="main">
+    <div class="module-content">
+        <h1 class="page-heading">Privacy policy</h1>
+        <h3>Data collection and use</h3>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+        </p>
+        <h3>Use of Data</h3>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+        </p>
+        <h3>Transfer of Data</h3>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+        </p>
+        <h3>Security of Data</h3>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+        </p>
+        <h3>Service providers</h3>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+        </p>
+    </div>
+</article>
+{% endblock %}

--- a/ckanext/gla/templates/user/edit_user_form.html
+++ b/ckanext/gla/templates/user/edit_user_form.html
@@ -11,3 +11,14 @@
         {{ form.markdown('about', label=_('About'), id='field-about', value=data.about, error=errors.about, placeholder=_('A little information about yourself')) }}
       </fieldset>
 {% endblock %}
+
+{% block form %}
+      {{ super() }}
+      <div class="delete-account">
+          <h6>Delete account</h6>
+          <p>
+              If you wish to delete your account, please <a href="mailto:admin@todo.com">email the site administrator</a> from the email address associated with your acocunt.
+              All personal data will be removed from our systems upon request in accordance with GDPR regulation. Further information can be found in the <a href="/privacy-policy">Privacy Policy</a>.
+          </p>
+      </div>
+{% endblock %}

--- a/ckanext/gla/views.py
+++ b/ckanext/gla/views.py
@@ -15,7 +15,7 @@ from ckan.types import Context
 
 favourites = Blueprint("favourites_blueprint", __name__)
 users = Blueprint("users_blueprint", __name__)
-
+privacy = Blueprint("privacy_blueprint", __name__)
 
 def show_favourites():
     # If an unregistered user ends up on the /dataset/following page
@@ -104,6 +104,10 @@ def view_user(id):
 
 users.add_url_rule("/user/<id>", methods=["GET"], view_func=view_user)
 
+def view_privacy():
+    return tk.render("privacy.html")
+
+privacy.add_url_rule("/privacy-policy", methods=["GET"], view_func=view_privacy)
 
 def get_blueprints():
-    return [favourites, users]
+    return [favourites, users, privacy]


### PR DESCRIPTION
* Add a page at `/privacy-policy`; currently just contains lorem ipsum.
* Link to this page in the footer
* In the user settings page, show instructions on how to delete your account by emailing the site admin and link to the privacy policy.