### PR TITLE
DAT 323 - Fix data quality boost

### DIFF
--- a/ckanext/gla/search.py
+++ b/ckanext/gla/search.py
@@ -6,6 +6,9 @@ import luqum.auto_head_tail as ht
 
 auto_head_tail = ht.AutoHeadTail()
 
+# Set the amount by which the data quality field boosts a result
+data_quality_boost_factor = 0.1
+
 def _parse_query(query):
     if query == "" or query is None:
         query = "*:*"
@@ -16,10 +19,12 @@ def _parse_query(query):
         return parsed
 
 def add_quality_to_search(search_params):
+    data_quality_boosts = [tree.Boost(tree.SearchField("extras_data_quality", tree.Term(str(quality))),
+                                      data_quality_boost_factor * quality)
+                           for quality in range(1, 6)]
     parsed_query = _parse_query(search_params.get("q"))
     boosted_query = tree.Plus(tree.Boost(parsed_query, 1))
-    data_quality_search = tree.Boost(tree.SearchField("extras_data_quality", tree.Range(tree.Word("0"),tree.Word("5"),include_high=True,include_low=True)), 0.1)
-    new_query = tree.OrOperation(boosted_query, data_quality_search)
+    new_query = tree.OrOperation(boosted_query, *data_quality_boosts)
     new_query = auto_head_tail(new_query)
     return {**search_params, "q": str(new_query)}
 


### PR DESCRIPTION
The previous implementation incorrectly boosted any results where the data quality was between 0 and 5 equally, instead of boosting based on the actual value. This fixes it by adding a boost for each possible value. At some point, we may want to use function queries to boost based on the data quality value instead, but luqum does not support this so I have gone with the simplest option for now.