### PR TITLE
DAT-320 - Properly display added and deleted resources

### DIFF
--- a/ckanext/gla/templates/snippets/changes/delete_resource.html
+++ b/ckanext/gla/templates/snippets/changes/delete_resource.html
@@ -1,0 +1,8 @@
+<li>
+    <p>
+        {{ _('Deleted resource {resource_link} from {pkg_link}').format(
+        resource_link = change.resource_name,
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        ) }}
+    </p>
+</li>

--- a/ckanext/gla/templates/snippets/changes/new_resource.html
+++ b/ckanext/gla/templates/snippets/changes/new_resource.html
@@ -1,0 +1,10 @@
+<li>
+    <p>
+        {{ _('Added resource {resource_link} to {pkg_link}').format(
+      resource_link = h.nav_link(
+        change.resource_name, named_route='resource.read', qualified=True, id=change.pkg_id,
+        resource_id = change.resource_id, activity_id=change.old_activity_id),
+      pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+      ) }}
+    </p>
+</li>


### PR DESCRIPTION
# Properly display added and deleted resources in dataset activity changes
This PR addresses the issue [discussed here](https://london.atlassian.net/browse/DAT-320?focusedCommentId=172824), which was caused when trying to display changes in the activity feed that include new resources being added to a dataset.

The issue has also been reported in the ckan/ckan repo here:
https://github.com/ckan/ckan/issues/6471

## Changes
- Created a `changes/new_resource.html` template to override the original in the [activity extension](https://github.com/ckan/ckan/blob/master/ckanext/activity/templates/snippets/changes/new_resource.html). The call to `url_for` in the original was failing.
For some reason the [delete_resource](https://github.com/ckan/ckan/blob/master/ckanext/activity/templates/snippets/changes/delete_resource.html) template uses `nav_link` instead of `url_for`, which seems to work Ok. So I've just copied that to use `nav_link` in the `new_resource.html` template.
- Created a `changes/delete_resource.html` template to override the [original](https://github.com/ckan/ckan/blob/master/ckanext/activity/templates/snippets/changes/new_resource.html). For some reason the `delete_resource` template gives a link to the deleted resource, which always gives a 404, because the resource has been deleted...
So I've removed the link and just show the name of the deleted resource.
