### PR TITLE
Feature/dat 340 prioritise upstream updated

### DIFF
--- a/ckanext/gla/helpers.py
+++ b/ckanext/gla/helpers.py
@@ -51,10 +51,6 @@ def remove_favourites(user, request, all_items):
 
 
 def last_updated(package):
-    if "extras" in package.keys():
-        for extra in package["extras"]:
-            if extra["key"] == "upstream_metadata_modified":
-                return extra["value"]
     return package.get("metadata_modified", "")
 
 

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -2,7 +2,7 @@ from ckan.types import Schema
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
-from . import auth, helpers, views, search
+from . import auth, helpers, views, search, timestamps
 
 
 class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
@@ -37,6 +37,12 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
         # Then add the quality parts to the search query:
         return search.add_quality_to_search(search_params)
+
+    def after_dataset_create(self, ctx, package):
+        timestamps.restore_upstream(ctx, package)
+
+    def after_dataset_update(self, ctx, package):
+        timestamps.restore_upstream(ctx, package)
 
     # ITemplateHelpers
     def get_helpers(self):

--- a/ckanext/gla/templates/package/snippets/additional_info.html
+++ b/ckanext/gla/templates/package/snippets/additional_info.html
@@ -10,28 +10,6 @@
         </td>
       </tr>
     {% endif %}
-    {% if extra.key == "upstream_metadata_modified" %}
-      <tr>
-        <th scope="row" class="dataset-label">Upstream Last Updated</th>
-        <td class="dataset-details">
-          {%
-            snippet 'snippets/local_friendly_datetime.html',
-            datetime_obj=extra.value
-          %}
-        </td>
-      </tr>
-    {% endif %}
-    {% if extra.key == "upstream_metadata_created" %}
-      <tr>
-        <th scope="row" class="dataset-label">Upstream Created</th>
-        <td class="dataset-details">
-          {%
-            snippet 'snippets/local_friendly_datetime.html',
-            datetime_obj=extra.value
-          %}
-        </td>
-      </tr>
-    {% endif %}
   {% endfor %}
   {% if pkg_dict.data_quality %}
     <tr>

--- a/ckanext/gla/timestamps.py
+++ b/ckanext/gla/timestamps.py
@@ -1,0 +1,38 @@
+import dateutil.parser
+
+
+def restore_upstream(ctx, package):
+    """
+    CKAN's dataset create/update method sets the metadata_created and
+    metadata_modified fields to the current time, with no option to override
+    them. We want to inherit the upstream fields, so patch them back to the
+    upstream values after every change.
+
+    Uses the SQLAlchemy interface directly to update the metadata fields.
+    """
+    for extra in package["extras"]:
+        if extra["key"] == "upstream_metadata_created":
+            metadata_created = dateutil.parser.parse(extra["value"])
+        if extra["key"] == "upstream_metadata_modified":
+            metadata_modified = dateutil.parser.parse(extra["value"])
+
+    if metadata_created is None or metadata_modified is None:
+        return
+
+    # CKAN assumes tzinfo is None (so that printed timestamps don't have
+    # timezone specifiers on them) so strip timezone information.
+    metadata_created = metadata_created.replace(tzinfo=None)
+    metadata_modified = metadata_modified.replace(tzinfo=None)
+
+    model = ctx["model"]
+
+    (
+        model.Session.query(model.Package)
+        .filter_by(id=package["id"])
+        .update(
+            {
+                "metadata_created": metadata_created,
+                "metadata_modified": metadata_modified,
+            }
+        )
+    )


### PR DESCRIPTION
CKAN doesn't provide a means to override the updated and created times on a dataset when creating or updating them, but we can use the `IPackageController` plugin methods `after_dataset_create` and `after_dataset_update` to change them immediately back again on creation and then on every change.

Uses the existing `upstream_metadata_modified` and `upstream_metadata_created` fields as the source of truth, but there's no need to render these on the dataset page any more since the `metadata_modified` and `metadata_created` fields will always be the same.