### PR TITLE
DAT-402 - Fix admin user search bug

### DIFF
--- a/ckanext/gla/assets/search_result_logging.js
+++ b/ckanext/gla/assets/search_result_logging.js
@@ -1,19 +1,20 @@
 function postSelectedSearchResult(data) {
-    var baseURL = window.location.origin;
-    var xhr = new XMLHttpRequest();
-    xhr.open('POST', baseURL + '/api/action/log_chosen_search_result', true);
-    xhr.setRequestHeader('Content-Type', 'application/json');
-    var jsonified = JSON.stringify(data);
-    return new Promise(function(resolve, reject) {
-        xhr.onload = function() {
-            if (xhr.status === 200) {
-                resolve();
-            } else {
-                reject(xhr.status);
-            }
-        };
+    const baseURL = window.location.origin;
+    const url = baseURL + '/api/action/log_chosen_search_result';
+    const jsonified = JSON.stringify(data);
 
-        xhr.send(jsonified);
+    return fetch(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: jsonified
+    }).then(function(response) {
+        if (response.ok) {
+            return;
+        } else {
+            throw new Error("Failed to log search result click");
+        }
     });
 }
 

--- a/ckanext/gla/assets/search_result_logging.js
+++ b/ckanext/gla/assets/search_result_logging.js
@@ -1,20 +1,19 @@
 function postSelectedSearchResult(data) {
-    const baseURL = window.location.origin;
-    const url = baseURL + '/api/action/log_chosen_search_result';
-    const jsonified = JSON.stringify(data);
+    var baseURL = window.location.origin;
+    var xhr = new XMLHttpRequest();
+    xhr.open('POST', baseURL + '/api/action/log_chosen_search_result', true);
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    var jsonified = JSON.stringify(data);
+    return new Promise(function(resolve, reject) {
+        xhr.onload = function() {
+            if (xhr.status === 200) {
+                resolve();
+            } else {
+                reject(xhr.status);
+            }
+        };
 
-    return fetch(url, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body: jsonified
-    }).then(function(response) {
-        if (response.ok) {
-            return;
-        } else {
-            throw new Error("Failed to log search result click");
-        }
+        xhr.send(jsonified);
     });
 }
 

--- a/ckanext/gla/search.py
+++ b/ckanext/gla/search.py
@@ -62,7 +62,7 @@ def _result_index(page, index_in_page):
     from ckan.common import config
     return page_idx * config.get('ckan.datasets_per_page') + int(index_in_page)
 
-@toolkit.side_effect_free
+@toolkit.auth_allow_anonymous_access
 def log_selected_result(context, data_dict={}):
     data_to_log = {k: v for k, v in data_dict.items() if k not in ["page", "index", "is_search_result"]}
     data_to_log["index"] = _result_index(data_dict["page"], data_dict["index"])


### PR DESCRIPTION
The call to the search logging endpoint 400'ed when the user was logged in as admin, because the session cookies were being included in the request but the csrf token wasn't there. Since this endpoint doesn't need any authentication, this change omits the credentials from the request and resolves the issue we were seeing, where the redirection  to the dataset page was blocked.