### PR TITLE
DAT-397 and DAT-395 - Remove sidebar on all pages

### DIFF
--- a/ckanext/gla/templates/organization/index.html
+++ b/ckanext/gla/templates/organization/index.html
@@ -10,9 +10,7 @@
 
 {% block upper_content %}
 <div class="row">
-    <div class="col-md-9 col-xs-12 offset-md-3">
     {% snippet 'snippets/search_form.html', form_id='organization-search-form', type=group_type, query=q, sorting_selected=sort_by_selected, count=page.item_count, placeholder=h.humanize_entity_type('organization', group_type, 'search placeholder') or _('Search organizations...'), show_empty=request.args, no_bottom_border=true if page.items, sorting = [(_('Name Ascending'), 'title asc'), (_('Name Descending'), 'title desc')] %}
-    </div>
 </div>
 {% endblock %}
 

--- a/ckanext/gla/templates/package/search.html
+++ b/ckanext/gla/templates/package/search.html
@@ -30,8 +30,6 @@
   </div>
   {% endblock %}
 
-{% block primary %}
-  <div class="primary" role="main">
 {% block primary_content %}
   <section class="module">
     <div class="">
@@ -78,10 +76,4 @@
       </div>
     </section>
   {% endblock %}
-{% endblock %}
-    </div>
-{% endblock %}
-
-
-{% block secondary %}
 {% endblock %}

--- a/ckanext/gla/templates/page-search.html
+++ b/ckanext/gla/templates/page-search.html
@@ -58,25 +58,10 @@
             {% endblock %}
 
             {% block secondary %}
-              <aside class="secondary col-md-3">
-                {#
-                The secondary_content block can be used to add content to the
-                sidebar of the page. This is the main block that is likely to be
-                used within a template.
-
-                Example:
-
-                  {% block secondary_content %}
-                    <h2>A sidebar item</h2>
-                    <p>Some content for the item</p>
-                  {% endblock %}
-                #}
-                {% block secondary_content %}{% endblock %}
-              </aside>
             {% endblock %}
 
             {% block primary %}
-              <div class="primary col-md-9 col-xs-12" role="main">
+              <div class="primary" role="main">
                 {% block primary_content %}
                   <article class="module">
                     {% block page_header %}


### PR DESCRIPTION
Setting the secondary content (ie sidebar) bllock to be empty on all pages solves two problems: removing the filters on the organization search page (this was missed when removing from dataset page for 395) and removing the organization description for 397. I have also made the search form at the top of the organization search full-width