### PR TITLE
DAT-309-243 Add LGOV scripts and GA

### DIFF
--- a/ckanext/gla/templates/base.html
+++ b/ckanext/gla/templates/base.html
@@ -3,3 +3,57 @@
 {% block custom_styles %}
 <link rel="stylesheet" href="/gla.css" />
 {% endblock %}
+
+{% block head_extras %}
+
+{# Cookie consent and analytics scripts are omitted on localhost
+to avoid spamming GA during dev work #}
+{% if "localhost" not in request.url %}
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-74XHH2DHHT"></script>
+    <script src="https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js" type="text/javascript"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-74XHH2DHHT');
+        var config = {
+            "apiKey": "8dc8f6b09522d6b36d669cd8f8eabe9927342b55",
+            "product": "COMMUNITY",
+            optionalCookies: [
+                {
+                    name: 'analytics',
+                label: 'Google Analytics',
+                    description: 'Analytical cookies help us to improve our website by collecting and reporting information on its usage.',
+                    cookies: ['_ga', '_gid', '_gat', '__utma', '__utmt', '__utmb', '__utmc', '__utmz', '__utmv'],
+                    onAccept: function(){
+                        gtag('consent', 'update', {'analytics_storage': 'granted'});
+                    },
+                onRevoke: function(){
+                        gtag('consent', 'update', {'analytics_storage': 'denied'});
+                }
+                },
+                {
+                    name: 'marketing',
+                    label: 'Google Ad Platforms',
+                    description: 'We use marketing cookies to help us improve the relevancy of advertising campaigns you receive.',
+                    onAccept: function(){
+                        gtag('consent', 'update', {'ad_storage': 'granted'});
+                    },
+                onRevoke: function(){
+                        gtag('consent', 'update', {'ad_storage': 'denied'});
+                }
+                }
+            ],
+            "iabCMP": false,
+            "necessaryCookies": ["ckan"],
+            "closeStyle": "button",
+            "notifyDismissButton": false,
+            "text": {"closeLabel": "Save Preferences"}
+        };
+        CookieControl.load( config );
+    </script>
+    <script type="text/javascript" src="https://www.london.gov.uk/modules/custom/lgov/gla_crisis_communication/gla-crisis-communication/dist/gla_crisis_communication.js"></script>
+{% endif %}
+{{ super() }}
+{% endblock %}

--- a/ckanext/gla/templates/footer.html
+++ b/ckanext/gla/templates/footer.html
@@ -10,6 +10,7 @@
                 <li><a href="#">Governance</a></li>
                 <li><a href="#">Standards</a></li>
                 <li><a href="/privacy-policy">Privacy Policy</a></li>
+                <li><a class="" onclick="CookieControl.open(config)">Cookie preferences</a></li>
             </ul>
           {% endblock %}
         </div>


### PR DESCRIPTION
Adds the following scripts:
* Cookie consent manager
* Crisis communication
* Google analytics

It also adds a link to the footer that opens the cookie manager panel.

To avoid sending a bunch of google analytics requests during local development, these are not added to the page head on localhost. You'll see the link in the footer, but it won't do anything on localhost.

I've configured the cookie manager with some options that seemed sensible to me because the default looked a little confusing in my opinion.

![image](https://github.com/GreaterLondonAuthority/dfl-ckanext/assets/20282373/787bc266-d9ba-434f-b735-75d86c84e03a)
