### PR TITLE
Remove quote from search query. Bugfix in timestamps

### DIFF
--- a/ckanext/gla/search.py
+++ b/ckanext/gla/search.py
@@ -24,7 +24,7 @@ def add_quality_to_search(search_params):
     if _empty_or_none(search_terms):
         q = "*:*"
     else:
-        q = f"text:{quote(search_terms)}"
+        q = f"text:{search_terms}"
     query = f"{q} _val_:copy_data_quality^{data_quality_boost_factor} _val_:copy_dataset_boost^{dataset_boost_boost_factor}"
 
     return {**search_params,

--- a/ckanext/gla/timestamps.py
+++ b/ckanext/gla/timestamps.py
@@ -10,6 +10,9 @@ def restore_upstream(ctx, package):
 
     Uses the SQLAlchemy interface directly to update the metadata fields.
     """
+    metadata_created = None
+    metadata_modified = None
+
     for extra in package["extras"]:
         if extra["key"] == "upstream_metadata_created":
             metadata_created = dateutil.parser.parse(extra["value"])


### PR DESCRIPTION
# Changes
The `quote` in the `add_quality_to_search` function was causing queries like `population ` to get parsed like this:
`"parsedquery": "+(+text:popul +text:20) +FunctionQuery(int(copy_data_quality))^0.1 +FunctionQuery(double(copy_dataset_boost))^1.0",`

Because the space was being encoded to `%20` and then only datasets including a literal `20` were being returned.

The changes to `timestamps.py` were needed because that function would throw an error if the `upstream_metadata_created` or `upstream_metadata_modified` keys did not exist (because in that case `metadata_created` and `metadata_modified` were accessed before being set).