### PR TITLE
DAT-352 - Make all fields on dataset edit page read-only

### DIFF
--- a/ckanext/gla/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/gla/templates/package/snippets/package_basic_fields.html
@@ -1,5 +1,88 @@
 {% ckan_extends %}
 
+{% block package_basic_fields_title %}
+{{
+    form.input('title',
+        id='field-title',
+        label=_('Title'),
+        placeholder=_('eg. A descriptive title'),
+        value=data.title,
+        classes=['control-full',
+        'control-large'],
+        attrs={'data-module': 'slug-preview-target', 'class': 'form-control', 'disabled': true})
+}}
+{% endblock %}
+
+{% block package_basic_fields_description %}
+{{
+    form.markdown('notes',
+        id='field-notes',
+        label=_('Description'),
+        placeholder=_('eg. Some useful notes about the data'),
+        value=data.notes,
+        attrs={'disabled': true })
+}}
+{% endblock %}
+
+{% block package_basic_fields_tags %}
+{% set tag_attrs = {'data-module': 'autocomplete',
+                    'data-module-tags': '',
+                    'data-module-source': '/api/2/util/tag/autocomplete?incomplete=?',
+                    'disabled': true } %}
+{{
+    form.input('tag_string',
+        id='field-tags',
+        label=_('Tags'),
+        value=data.tag_string,
+        classes=['control-full'],
+        attrs=tag_attrs)
+}}
+{% endblock %}
+
+{% block package_basic_fields_license %}
+{{
+    form.input('license_id',
+        id='field-license',
+        label='License',
+        value=data.get('license_id'),
+        classes=['control-full'],
+        attrs={'disabled': true})
+}}
+{% endblock %}
+
+{% block package_metadata_fields_visibility %}
+{{
+    form.input('visability',
+        id='field-visablity',
+        label='Visibility',
+        value= 'Private' if data.private else 'Public',
+        classes=['control-full'],
+        attrs={'disabled': true})
+}}
+{% endblock %}
+
+{% block package_basic_fields_org %}
+
+{{
+form.input('organization',
+id='field-organization',
+label='Organization',
+value= data.owner_org,
+classes=['control-full'],
+attrs={'disabled': true})
+}}
+
+
+{{
+form.input('visability',
+id='field-visablity',
+label='Visibility',
+value= 'Private' if data.private else 'Public',
+classes=['control-full'],
+attrs={'disabled': true})
+}}
+  {% endblock %}
+
 {% block package_basic_fields_custom %}
 {{
     form.input("data_quality",

--- a/ckanext/gla/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/gla/templates/package/snippets/package_basic_fields.html
@@ -9,7 +9,7 @@
         value=data.title,
         classes=['control-full',
         'control-large'],
-        attrs={'data-module': 'slug-preview-target', 'class': 'form-control', 'disabled': true})
+        attrs={'data-module': 'slug-preview-target', 'class': 'form-control', 'readonly': true})
 }}
 {% endblock %}
 
@@ -20,7 +20,7 @@
         label=_('Description'),
         placeholder=_('eg. Some useful notes about the data'),
         value=data.notes,
-        attrs={'disabled': true })
+        attrs={'readonly': true })
 }}
 {% endblock %}
 
@@ -28,7 +28,7 @@
 {% set tag_attrs = {'data-module': 'autocomplete',
                     'data-module-tags': '',
                     'data-module-source': '/api/2/util/tag/autocomplete?incomplete=?',
-                    'disabled': true } %}
+                    'readonly': true } %}
 {{
     form.input('tag_string',
         id='field-tags',
@@ -46,7 +46,7 @@
         label='License',
         value=data.get('license_id'),
         classes=['control-full'],
-        attrs={'disabled': true})
+        attrs={'readonly': true})
 }}
 {% endblock %}
 
@@ -57,7 +57,7 @@
         label='Visibility',
         value= 'Private' if data.private else 'Public',
         classes=['control-full'],
-        attrs={'disabled': true})
+        attrs={'readonly': true})
 }}
 {% endblock %}
 
@@ -69,7 +69,7 @@ id='field-organization',
 label='Organization',
 value= data.owner_org,
 classes=['control-full'],
-attrs={'disabled': true})
+attrs={'readonly': true})
 }}
 
 
@@ -79,7 +79,7 @@ id='field-visablity',
 label='Visibility',
 value= 'Private' if data.private else 'Public',
 classes=['control-full'],
-attrs={'disabled': true})
+attrs={'readonly': true})
 }}
   {% endblock %}
 

--- a/ckanext/gla/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/gla/templates/package/snippets/package_metadata_fields.html
@@ -1,0 +1,21 @@
+{% ckan_extends %}
+
+  {% block package_metadata_fields_url %}
+    {{ form.input('url', label=_('Source'), id='field-url', placeholder=_('http://example.com/dataset.json'), value=data.url, error=errors.url, classes=['control-full'], attrs={'disabled': true }) }}
+  {% endblock %}
+
+  {% block package_metadata_fields_version %}
+    {{ form.input('version', label=_('Version'), id='field-version', placeholder=_('1.0'), value=data.version, error=errors.version, classes=['control-full'], attrs={'disabled': true }) }}
+  {% endblock %}
+
+  {% block package_metadata_author %}
+    {{ form.input('author', label=_('Author'), id='field-author', placeholder=_('N/A'), value=data.author, error=errors.author, classes=['control-full'], attrs={'disabled': true }) }}
+
+{{ form.input('author_email', label=_('Author Email'), id='field-author-email', placeholder=_('N/A'), value=data.author_email, error=errors.author_email, classes=['control-full'], attrs={'disabled': true }) }}
+  {% endblock %}
+
+  {% block package_metadata_fields_maintainer %}
+{{ form.input('maintainer', label=_('Maintainer'), id='field-maintainer', placeholder=_('N/A'), value=data.maintainer, error=errors.maintainer, classes=['control-full'], attrs={'disabled': true }) }}
+
+{{ form.input('maintainer_email', label=_('Maintainer Email'), id='field-maintainer-email', placeholder=_('N/A'), value=data.maintainer_email, error=errors.maintainer_email, classes=['control-full'], attrs={'disabled': true }) }}
+  {% endblock %}


### PR DESCRIPTION
Prevents admins from editing anything about the dataset except for the data quality and boost factor. I have prevented toggling between private and public visibility as we intend to use the delete/undelete feature for this.