### PR TITLE
DAT-346 - Shrink More Information button on narrow screen

### DIFF
--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -1036,6 +1036,18 @@ form.lang-select select {
     min-height: 74px;
 }
 
+@media (max-width: 575.98px) {
+    .resource-item .btn-group {
+        display: block;
+    }
+}
+
+@media (max-width: 992px) {
+    .resource-item .btn-text {
+        display: none;
+    }
+}
+
 .resource-item:hover {
     background: var(--t-colors-off-white);
 }

--- a/ckanext/gla/templates/package/snippets/resource_item.html
+++ b/ckanext/gla/templates/package/snippets/resource_item.html
@@ -11,7 +11,7 @@
         <div class="dropdown btn-group">
             <a href="{{ url }}" class="btn btn-primary" type="button">
                 <i class="fa fa-info-circle"></i>
-                {{ _('More information') }}
+                <span class="btn-text">{{ _('More information') }}</span>
             </a>
         </div>
     {% endif %}


### PR DESCRIPTION
# More Information button on mobile
This PR addresses [DAT-346](https://london.atlassian.net/browse/DAT-346), and in particular the issue that the More Information button for resources is not visible on mobile-size screens.
## Changes
- Added some CSS to override the default behaviour of the button and make sure it says visible.
- Added a span around the button text and some CSS to hide the button text when the screen is below 992px wide.