### PR TITLE
Fix bug in data quality search term

### DIFF
--- a/ckanext/gla/search.py
+++ b/ckanext/gla/search.py
@@ -21,7 +21,7 @@ def _empty_or_none(string):
 
 def add_quality_to_search(search_params):
     search_terms = search_params.get("q")
-    if _empty_or_none(search_terms):
+    if _empty_or_none(search_terms) or search_terms == "*:*":
         q = "*:*"
     else:
         q = f"text:{search_terms}"


### PR DESCRIPTION
I spotted this error in the Solr logs:
`Cannot parse 'text:*:* _val_:copy_data_quality^0.1 _val_:copy_dataset_boost^1': Encountered " ":" ": "" at line 1, column 6.`  

When a search query came through as `*:*` it was being transformed into `text:*:*` (which Solr can't parse) instead of being left as `*:*`,