### PR TITLE
Bugfix/dat 404 file icons

### DIFF
--- a/ckanext/gla/helpers.py
+++ b/ckanext/gla/helpers.py
@@ -68,6 +68,8 @@ def extract_resource_format(resource):
     resource_type = resource.get("format", "data").lower()
     if resource_type == "spreadsheet":
         return "xls"
+    elif resource_type == "image":
+        return "png"
     else:
         return resource_type
 

--- a/ckanext/gla/templates/snippets/search_result_text.html
+++ b/ckanext/gla/templates/snippets/search_result_text.html
@@ -67,7 +67,7 @@
     
     <span>
     {% if type == 'dataset' %}
-        {% set text_query = ungettext('{number} dataset', '{number} datasets"', count) %}
+        {% set text_query = ungettext('{number} dataset', '{number} datasets', count) %}
         {% set text_query_none = _('No datasets found') %}
         {% set text_no_query = ungettext('{number} dataset', '{number} datasets', count) %}
         {% set text_no_query_none = _('No datasets found') %}


### PR DESCRIPTION
Related to: https://github.com/GreaterLondonAuthority/dfl-ckanext-havester/pull/7

If a resource still comes through with `format: 'image'` then set it to `png` manually so the icon is at least something that represents an image, rather than just the generic `data` icon.