### PR TITLE
DAT-442: CKAN Docker 2.10.1

### DIFF
--- a/ckanext/gla/assets/search_result_logging.js
+++ b/ckanext/gla/assets/search_result_logging.js
@@ -19,9 +19,8 @@ function postSelectedSearchResult(data) {
 
 
 function logResultClick(event, element, data) {
-    if( data["is_search_result"] == "True") {
-        event.preventDefault();
-        postSelectedSearchResult(data).then(function() {
+    if (data["is_search_result"] == "True") {
+        postSelectedSearchResult(data).then(function () {
             window.location.href = element.getAttribute('href');
         });
     }

--- a/ckanext/gla/search.py
+++ b/ckanext/gla/search.py
@@ -47,7 +47,7 @@ def debug(context, data_dict={}):
         except Exception as e:
             raise common.SearchError(e.args)
 
-logfile = "/srv/app/search_logs.csv"
+logfile = "/logs/search_logs.csv"
 
 def _result_index(page, index_in_page):
     page_idx = 0 if _empty_or_none(page) else int(page) - 1

--- a/ckanext/gla/views.py
+++ b/ckanext/gla/views.py
@@ -1,6 +1,7 @@
 from os.path import exists
 from flask import Blueprint, send_file
 
+import ckan
 import ckan.model as model
 import ckan.plugins.toolkit as tk
 
@@ -92,6 +93,22 @@ def _extra_template_variables(
 # Copied from:
 # https://github.com/ckan/ckan/blob/3c676e3cf1f075c5e9bae3b625b86247edf3cc1d/ckan/views/user.py#L124
 def view_user(id):
+    match id:
+        case "me":
+            return ckan.views.user.me()
+        case "edit":
+            return ckan.views.user._edit_view()
+        case "register":
+            return ckan.views.user.RegisterView.as_view("register")
+        case "login":
+            return ckan.views.user.login()
+        case "_logout":
+            return ckan.views.user.logout()
+        case "logged_out_redirect":
+            return ckan.views.user.logged_out_page()
+        case "reset":
+            return ckan.views.user.RequestResetView.as_view("request_reset")
+
     context = cast(
         Context,
         {


### PR DESCRIPTION
 Upgrade CKAN Docker
This PR makes some changes that were required to fix some bugs that appeared when upgrading to CKAN 2.10.1. The PR for the upgrade is [here](https://github.com/GreaterLondonAuthority/Data_for_London/pull/59).

## Changes
### Search logs
- Removed `preventDefault` from the search results logging javascript. We've had a problem for a little while where sometimes you click on a search result link and it doesn't take you to the dataset page. I managed to fix it by removing the `preventDefault`. I've not really been able to figure out why - I wouldn't be surprised if CKAN somehow hooks into the default behaviour and does _something_ when a link is clicked, and preventing it doing that somehow broke it ?
- Updated the search logs file path. See the [other PR](https://github.com/GreaterLondonAuthority/Data_for_London/pull/59) for some details.

### View user
I've updated our `view_user` function to manually check whether we're intercepting any of the default routes, and call the default route handler functions where required.

**We shouldn't have had to do this, this was working fine previously.** 

We originally added the `view_user` function so that we could return a 403 error when an unauthenticated user tries to access user accounts. Previously the error would be a 403 or 404 depending on whether the target user account existed, an that would allow an unauthenticated user to figure out the usernames of other users.

Somehow something has changed in CKAN and/or Flask and/or Werkzeug which means that our new `/user/<id>` route is intercepting all other `/user/...` routes, e.g. `/user/login`, `/user/logout` etc.

Flask uses Werkzeug to handle routing and according to the docs: https://flask.palletsprojects.com/en/3.0.x/design/#the-routing-system you should be able to: `declare routes in arbitrary order and they will still work as expected`.

This is definitely not working as advertised at the moment.

There are probably other ways to work around this - I just did the simplest thing for now. But what I've done could cause problems if there are `/user/...` routes defined in other extensions which accidentally get intercepted by our route.

It looks like there has been some recent work to upgrade Werkzeug which might solve this issue, so this is maybe something we could come back to later, when CKAN 2.10.2 or 2.11 is released.
https://github.com/ckan/ckan/pull/7463/files#diff-3fcde3a06f17437374b4510cc0c57d62477501f8825063fa84b6e1509e6ab93bR229
