### PR TITLE
Fix register and password reset pages

### DIFF
--- a/ckanext/gla/views.py
+++ b/ckanext/gla/views.py
@@ -99,7 +99,7 @@ def view_user(id):
         case "edit":
             return ckan.views.user._edit_view()
         case "register":
-            return ckan.views.user.RegisterView.as_view("register")
+            return ckan.views.user.RegisterView.as_view("register")()
         case "login":
             return ckan.views.user.login()
         case "_logout":
@@ -107,7 +107,7 @@ def view_user(id):
         case "logged_out_redirect":
             return ckan.views.user.logged_out_page()
         case "reset":
-            return ckan.views.user.RequestResetView.as_view("request_reset")
+            return ckan.views.user.RequestResetView.as_view("request_reset")()
 
     context = cast(
         Context,


### PR DESCRIPTION
# Bugfix for register and password reset pages
When I made the changes in #31 I apparently didn't test the register and password reset pages properly, because there was an error when trying to load them:
```
The view function did not return a valid response. The return type must be a string, dict, tuple, Response instance, or WSGI callable, but it was a function.
```

This is easily fixed by e.g. calling the `ckan.views.user.RegisterView.as_view("register")` function, rather than returning thr function itself.