### PR TITLE
Archive dataset

### DIFF
--- a/ckanext/gla/custom_fields.py
+++ b/ckanext/gla/custom_fields.py
@@ -5,32 +5,41 @@ import json
 import os
 
 
-
 solr_endpoint = os.getenv("CKAN_SOLR_URL")
+
 
 def float_validator(value):
     """Ensures that the value is a float and rounds to 4dp."""
     try:
         value = float(value)
-        return round(value,4)
+        return round(value, 4)
     except:
-        raise Invalid('Must be a number')
+        raise Invalid("Must be a number")
+
 
 custom_dataset_fields = {
+    "archived": [
+        toolkit.get_validator("boolean_validator"),
+        toolkit.get_converter("convert_to_extras"),
+    ],
+    "archived_description": [
+        toolkit.get_validator("ignore_missing"),
+        toolkit.get_converter("convert_to_extras"),
+    ],
     "data_quality": [
         toolkit.get_validator("int_validator"),
         toolkit.get_validator("one_of")([None, 1, 2, 3, 4, 5]),
         toolkit.get_converter("convert_to_extras"),
     ],
-    "dataset_boost": [
-        float_validator,
-        toolkit.get_converter("convert_to_extras")
-    ]
+    "dataset_boost": [float_validator, toolkit.get_converter("convert_to_extras")],
 }
 
 
-fields_to_copy = {"extras_data_quality": {"type": "int", "name": "copy_data_quality"},
-                  "extras_dataset_boost": {"type": "double", "name": "copy_dataset_boost"}}
+fields_to_copy = {
+    "extras_data_quality": {"type": "int", "name": "copy_data_quality"},
+    "extras_dataset_boost": {"type": "double", "name": "copy_dataset_boost"},
+}
+
 
 def field_exists(field_name):
     api_url = f"{solr_endpoint}/schema/fields/{field_name}"

--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -1524,3 +1524,8 @@ div#followee-filter {
 .dataset-content .container {
     padding: 0;
 }
+
+.archived-header {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+}

--- a/ckanext/gla/templates/package/read.html
+++ b/ckanext/gla/templates/package/read.html
@@ -1,0 +1,17 @@
+{% ckan_extends %}
+
+{% block page_heading %}
+{{ super() }}
+{% if pkg.archived == 'true' %}
+    [{{_('Archived')}}]
+{% endif %}
+{% endblock %}
+
+{% block package_notes %}
+{% if pkg.archived == 'true' and pkg.archived_description %}
+<h2 class="h3 archived-header">
+    {{h.render_markdown(h.get_translated(pkg, 'archived_description'))}}
+</h2>
+{% endif %}
+{{ super() }}
+{% endblock %}

--- a/ckanext/gla/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/gla/templates/package/snippets/package_basic_fields.html
@@ -117,5 +117,22 @@ attrs={'class': 'form-control', 'readonly': true})
         error=errors.dataset_boost,
         classes=["control-medium"])
 }}
+{{
+    form.checkbox("archived", 
+        id="field-dataset-archived",
+        label=_("Archive dataset"), 
+        value="true",
+        checked=data.archived == 'true',
+        classes=["control-medium"])
+}}
+{{
+    form.textarea("archived_description", 
+        id="field-dataset-archived-desc",
+        label=_("Reason for archiving"), 
+        value=data.archived_description,
+        placeholder=_("Reason for archiving"),
+        error=errors.archived_description,
+        classes=["control-medium"])
+}}
 
 {% endblock %}


### PR DESCRIPTION
# Archive dataset
This PR address [DAT-16](https://london.atlassian.net/browse/DAT-16) and adds the ability to display a dataset as archived.

## Changes
- Added `archived` and `archived_description` to `custom_fields.py`. 
- Added `archived` and `archived_description` to `package_basic_fields.py` which is the template used for the create and edit dataset form. 
  - `archived` in`custom_fields.py` uses a [boolean_validator](https://docs.ckan.org/en/2.10/extensions/validators.html#ckan.logic.validators.boolean_validator), so I've set the `value` of the checkbox in `package_basic_fields.html` to `true`, so that it can trigger that validator. 
  - `archived_description` uses a textarea, and also supports markdown so that links to other datasets can be put in the description.
- Added a new `read.html` template which is used to display the dataset details page. It extends the default ckan version of the template and adds in an `[Archived]` label and the archived description, if they exist.

## Examples
### Edit dataset page:
![Screen Shot 2023-11-09 at 4 15 31 PM](https://github.com/GreaterLondonAuthority/dfl-ckanext/assets/1217533/38121635-fcd2-4518-b9b2-cbb060948ca8)

### Dataset page after "Archive dataset" is ticked:
![Screen Shot 2023-11-09 at 4 11 38 PM](https://github.com/GreaterLondonAuthority/dfl-ckanext/assets/1217533/619acbc5-dd5f-458e-8d28-b167edce6b43)
