### PR TITLE
DAT-482: Author details

### DIFF
--- a/ckanext/gla/templates/package/snippets/additional_info.html
+++ b/ckanext/gla/templates/package/snippets/additional_info.html
@@ -1,20 +1,112 @@
 {% ckan_extends %}
-
-{% block extras %}
-  {% for extra in pkg_dict.extras %}
-    {% if extra.key == "upstream_url" %}
+<section class="additional-info">
+  <h3>{{ _('Additional Info') }}</h3>
+  <table class="table table-striped table-bordered table-condensed">
+    <thead>
       <tr>
-        <th scope="row" class="dataset-label">Upstream URL</th>
-        <td class="dataset-details">
-          <a href="{{ extra.value }}">{{ extra.value }}</a>
-        </td>
+        <th scope="col">{{ _('Field') }}</th>
+        <th scope="col">{{ _('Value') }}</th>
       </tr>
-    {% endif %}
-  {% endfor %}
-  {% if pkg_dict.data_quality %}
-    <tr>
-      <th scope="row" class="dataset-label">Data Quality</th>
-      <td class="dataset-details">{{ pkg_dict.data_quality }}</td>
-    </tr>
-  {% endif %}
-{% endblock %}
+    </thead>
+    <tbody>
+      {% block package_additional_info %}
+        {% if pkg_dict.url %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _('Source') }}</th>
+            {% if h.is_url(pkg_dict.url) %}
+              <td class="dataset-details" property="foaf:homepage">
+                <a href="{{ pkg_dict.url }}" rel="foaf:homepage" target="_blank">
+                  {{ pkg_dict.url }}
+                </a>
+              </td>
+            {% else %}
+              <td class="dataset-details" property="foaf:homepage">{{ pkg_dict.url }}</td>
+            {% endif %}
+          </tr>
+        {% endif %}
+
+        {% if pkg_dict.author_email %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("Author") }}</th>
+            {% if pkg_dict.author %}
+              <td class="dataset-details" property="dc:creator">{{ h.mail_to(email_address=pkg_dict.author_email, name=pkg_dict.author) }}</td>
+            {% else %}
+              <td class="dataset-details" property="dc:creator">{{ h.mail_to(email_address=pkg_dict.author_email, name=pkg_dict.author_email) }}</td>
+            {% endif %}
+          </tr>
+        {% elif pkg_dict.author %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("Author") }}</th>
+            <td class="dataset-details" property="dc:creator">{{ pkg_dict.author }}</td>
+          </tr>
+        {% endif %}
+
+        {% if pkg_dict.maintainer_email %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _('Maintainer') }}</th>
+            <td class="dataset-details" property="dc:contributor">{{ h.mail_to(email_address=pkg_dict.maintainer_email, name=pkg_dict.maintainer) }}</td>
+          </tr>
+        {% elif pkg_dict.maintainer %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _('Maintainer') }}</th>
+            <td class="dataset-details" property="dc:contributor">{{ pkg_dict.maintainer }}</td>
+          </tr>
+        {% endif %}
+
+        {% if pkg_dict.version %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("Version") }}</th>
+            <td class="dataset-details">{{ pkg_dict.version }}</td>
+          </tr>
+        {% endif %}
+
+        {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("State") }}</th>
+            <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
+          </tr>
+        {% endif %}
+        {% if pkg_dict.metadata_modified %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("Last Updated") }}</th>
+            <td class="dataset-details">
+                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_modified %}
+            </td>
+          </tr>
+        {% endif %}
+        {% if pkg_dict.metadata_created %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("Created") }}</th>
+
+            <td class="dataset-details">
+                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_created %}
+            </td>
+          </tr>
+        {% endif %}
+
+        {% block extras %}
+        {% for extra in pkg_dict.extras %}
+          {% if extra.key == "upstream_url" %}
+            <tr>
+              <th scope="row" class="dataset-label">Upstream URL</th>
+              <td class="dataset-details">
+                <a href="{{ extra.value }}">{{ extra.value }}</a>
+              </td>
+            </tr>
+          {% endif %}
+        {% endfor %}
+        {% if pkg_dict.data_quality %}
+          <tr>
+            <th scope="row" class="dataset-label">Data Quality</th>
+            <td class="dataset-details">{{ pkg_dict.data_quality }}</td>
+          </tr>
+        {% endif %}
+        {% endblock %}
+
+      {% endblock %}
+    </tbody>
+  </table>
+</section>
+
+
+

--- a/ckanext/gla/templates/package/snippets/additional_info.html
+++ b/ckanext/gla/templates/package/snippets/additional_info.html
@@ -44,7 +44,11 @@
         {% if pkg_dict.maintainer_email %}
           <tr>
             <th scope="row" class="dataset-label">{{ _('Maintainer') }}</th>
-            <td class="dataset-details" property="dc:contributor">{{ h.mail_to(email_address=pkg_dict.maintainer_email, name=pkg_dict.maintainer) }}</td>
+            {% if pkg_dict.maintainer %}
+              <td class="dataset-details" property="dc:contributor">{{ h.mail_to(email_address=pkg_dict.maintainer_email, name=pkg_dict.maintainer) }}</td>
+            {% else %}
+              <td class="dataset-details" property="dc:contributor">{{ h.mail_to(email_address=pkg_dict.maintainer_email, name=pkg_dict.maintainer_email) }}</td>
+            {% endif %}
           </tr>
         {% elif pkg_dict.maintainer %}
           <tr>


### PR DESCRIPTION
This PR address [DAT-482](https://london.atlassian.net/browse/DAT-482) and modifies how dataset author details are displayed on the dataset page.

Most of the  acceptance requirements are provided by CKAN by default:
- If both the author name and email are given, the name is displayed with a mailto link to the email  ✅ 
- If only the author name is given, that name is displayed in the table  ✅ 
- If neither the author name or email are given, the author details are not displayed in the additional info table. ✅ 

However, if only the author email is given the CKAN template will try and display the non-existant author name, which will end up as a blank row in the table. This needed updating in the `additional_info` template.

The default CKAN `additional_info` page doesn't have individual blocks for each of the additional info items, so I've had to copy across the entire template and just change the bits I needed.

The only change to the [CKAN template](https://github.com/ckan/ckan/blob/master/ckan/templates/package/snippets/additional_info.html) is an extra `{% if %}` block inside the author_email row. If there's no author name given then the email address itself will be displayed in the table cell.

