### PR TITLE
DAT-455 Un-delete via button

### DIFF
--- a/ckanext/gla/custom_fields.py
+++ b/ckanext/gla/custom_fields.py
@@ -17,6 +17,15 @@ def float_validator(value):
         raise Invalid("Must be a number")
 
 
+def data_quality_validator(value):
+    try:
+        value = int(value)
+        if 1 <= value <= 5:
+            return value
+        raise Invalid("Must be between 1 and 5")
+    except:
+        raise Invalid("Must be integer")
+
 custom_dataset_fields = {
     "archived": [
         toolkit.get_validator("boolean_validator"),
@@ -27,8 +36,8 @@ custom_dataset_fields = {
         toolkit.get_converter("convert_to_extras"),
     ],
     "data_quality": [
-        toolkit.get_validator("int_validator"),
-        toolkit.get_validator("one_of")([None, 1, 2, 3, 4, 5]),
+        toolkit.get_validator("ignore_empty"),
+        data_quality_validator,
         toolkit.get_converter("convert_to_extras"),
     ],
     "dataset_boost": [float_validator, toolkit.get_converter("convert_to_extras")],

--- a/ckanext/gla/templates/package/edit_base.html
+++ b/ckanext/gla/templates/package/edit_base.html
@@ -1,0 +1,20 @@
+{% ckan_extends %}
+{% import 'macros/form.html' as form %}
+
+{% block content_action %}
+    <div class="d-flex flex-row justify-content-between mb-4">
+        {{ super() }}
+        {% if pkg.state == "deleted" %}
+            <form id="dataset-undelete"
+                  method="post"
+                  action="/dataset/{{ pkg.id }}/undelete"
+                  data-module="basic-form" novalidate>
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="btn btn-default">
+                    <i class="fa fa-undo" style="color: var(--t-colors-pink);"></i>
+                    Undelete dataset
+                </button>
+            </form>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/ckanext/gla/views.py
+++ b/ckanext/gla/views.py
@@ -23,7 +23,7 @@ favourites = Blueprint("favourites_blueprint", __name__)
 users = Blueprint("users_blueprint", __name__)
 privacy = Blueprint("privacy_blueprint", __name__)
 search_log_download = Blueprint("search_log_download_blueprint", __name__)
-
+undelete = Blueprint("undelete_blueprint", __name__)
 
 def show_favourites():
     log.info("IN SHOW_FAVOURITES")
@@ -162,6 +162,15 @@ search_log_download.add_url_rule(
     "/search_logs", methods=["GET"], view_func=get_server_search_logs
 )
 
+def undelete_package(id):
+    res = tk.get_action("package_patch")(None, {"id": id, "state": "active"})
+    return tk.redirect_to('dataset.read', id=id)
+
+
+undelete.add_url_rule("/dataset/<id>/undelete",
+                      methods=["POST"],
+                      view_func=undelete_package,
+                      endpoint="undelete_package")
 
 def get_blueprints():
-    return [favourites, users, privacy, search_log_download]
+    return [favourites, users, privacy, search_log_download, undelete]


### PR DESCRIPTION
When a dataset is deleted, an admin can now re-instate it via a button on the top of the 'edit' page like this:

![image](https://github.com/GreaterLondonAuthority/dfl-ckanext/assets/20282373/25bd3e54-451b-4fa9-985a-ba010a5bfdbe)

When clicked, the dataset is un-deleted and the user is redirected to the dataset view page