### PR TITLE
DAT-537 - Remove breadcrumbs

### DIFF
--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -502,50 +502,6 @@ input#field-sitewide-search::-ms-input-placeholder {
     overflow: hidden;
 }
 
-/* Breadcrumbs */
-
-
-.breadcrumb .fa-home {
-    display: none;
-}
-
-.toolbar .home span {
-    display: block;
-}
-
-.toolbar .breadcrumb li:not(:first-child)::before {
-    content: "";
-    display: block;
-    width: 10px;
-    height: 10px;
-    border: 2px solid var(--t-colors-pink);
-    border-width: 2px 2px 0 0;
-    transform: rotate(45deg);
-    position: relative;
-    top: 10px;
-    margin-right: 10px;
-}
-
-.toolbar .breadcrumb .active {
-    font-weight: bold;
-    color: var(--t-colors-text-grey);
-}
-
-.toolbar .breadcrumb a,
-.toolbar .home a {
-    text-decoration: none;
-    display: inline-block;
-    line-height: 1;
-    padding-bottom: 2px;
-}
-
-.toolbar .breadcrumb a:hover,
-.toolbar .home a:hover {
-    color: var(--t-colors-pink);
-    border-bottom: 2px solid var(--t-colors-pink);
-    text-decoration: none;
-}
-
 /* Box / Wrapper */
 
 .box,

--- a/ckanext/gla/templates/page-search.html
+++ b/ckanext/gla/templates/page-search.html
@@ -32,18 +32,6 @@
             </div>
           {% endblock %}
 
-          {% block toolbar %}
-            <div class="toolbar" role="navigation" aria-label="{{ _('Breadcrumb') }}">
-              {% block breadcrumb %}
-                {% if self.breadcrumb_content() | trim %}
-                  <ol class="breadcrumb">
-                    {% snippet 'snippets/home_breadcrumb_item.html' %}
-                    {% block breadcrumb_content %}{% endblock %}
-                  </ol>
-                {% endif %}
-              {% endblock %}
-            </div>
-          {% endblock %}
           <!-- Upper content, title and search box here -->
           {% block upper_content %}
           {% endblock %}

--- a/ckanext/gla/templates/page.html
+++ b/ckanext/gla/templates/page.html
@@ -32,18 +32,6 @@
             </div>
           {% endblock %}
 
-          {% block toolbar %}
-            <div class="toolbar" role="navigation" aria-label="{{ _('Breadcrumb') }}">
-              {% block breadcrumb %}
-                {% if self.breadcrumb_content() | trim %}
-                  <ol class="breadcrumb">
-                    {% snippet 'snippets/home_breadcrumb_item.html' %}
-                    {% block breadcrumb_content %}{% endblock %}
-                  </ol>
-                {% endif %}
-              {% endblock %}
-            </div>
-          {% endblock %}
           <div class="row wrapper{% block wrapper_class %}{% endblock %}{% if self.secondary()|trim == '' or c.action=='resource_read' %} no-nav{% endif %}">
             {#
             The pre_primary block can be used to add content to before the


### PR DESCRIPTION
This removes the breadcrumbs from the top of all pages. I have done this using the base template and left the breadcrumb content in place for other pages so we can easily re-add the component if needed later.