### PR TITLE
Override dataset last_modified timestamps

### DIFF
--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -40,10 +40,10 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         return search.add_quality_to_search(search_params)
 
     def after_dataset_create(self, ctx, package):
-        timestamps.restore_upstream(ctx, package)
+        timestamps.override(ctx, package)
 
     def after_dataset_update(self, ctx, package):
-        timestamps.restore_upstream(ctx, package)
+        timestamps.override(ctx, package)
 
     # ITemplateHelpers
     def get_helpers(self):

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -9,6 +9,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IAuthFunctions, inherit=True)
     plugins.implements(plugins.IPackageController, inherit=True)
+    plugins.implements(plugins.IResourceController, inherit=True)
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IActions)
@@ -44,6 +45,9 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
     def after_dataset_update(self, ctx, package):
         timestamps.override(ctx, package)
+
+    def after_resource_delete(self, ctx, resources):
+        timestamps.set_to_now(ctx, resources)
 
     # ITemplateHelpers
     def get_helpers(self):

--- a/ckanext/gla/timestamps.py
+++ b/ckanext/gla/timestamps.py
@@ -1,12 +1,14 @@
 import dateutil.parser
 
+import ckan.plugins.toolkit as tk
 
-def restore_upstream(ctx, package):
+
+def override(ctx, package):
     """
     CKAN's dataset create/update method sets the metadata_created and
     metadata_modified fields to the current time, with no option to override
-    them. We want to inherit the upstream fields, so patch them back to the
-    upstream values after every change.
+    them. We want to inherit the upstream fields when they exist, or set the
+    dataset's last modified time to match the most recently updated resource.
 
     Uses the SQLAlchemy interface directly to update the metadata fields.
     """
@@ -19,23 +21,37 @@ def restore_upstream(ctx, package):
         if extra["key"] == "upstream_metadata_modified":
             metadata_modified = dateutil.parser.parse(extra["value"])
 
+    # If there's no upstream fields then this isn't a harvested dataset,
+    # so set the last modified date based on the dataset's resources
     if metadata_created is None or metadata_modified is None:
-        return
+        p = tk.get_action("package_show")(None, {"id": package["id"]})
 
-    # CKAN assumes tzinfo is None (so that printed timestamps don't have
-    # timezone specifiers on them) so strip timezone information.
-    metadata_created = metadata_created.replace(tzinfo=None)
-    metadata_modified = metadata_modified.replace(tzinfo=None)
+        def resource_date(resource):
+            return resource.get("last_modified") or resource.get("created")
+
+        # For each of the dataset's resources, get the "last_modified" timestamp
+        # or the "created" timestamp if that doesn't exist
+        resource_modified_dates = [resource_date(r) for r in p["resources"]]
+
+        # Sort the timestamps in descending order and get the first one
+        most_recent = sorted(resource_modified_dates, reverse=True)[0]
+        most_recent_datetime = dateutil.parser.parse(most_recent)
+        updated_timestamps = {
+            "metadata_modified": most_recent_datetime.replace(tzinfo=None)
+        }
+    else:
+        updated_timestamps = {
+            # CKAN assumes tzinfo is None (so that printed timestamps don't have
+            # timezone specifiers on them) so strip timezone information.
+            "metadata_created": metadata_created.replace(tzinfo=None),
+            "metadata_modified": metadata_modified.replace(tzinfo=None),
+        }
 
     model = ctx["model"]
 
+    # Use SQLAlchemy directly to avoid re-triggering after_package_update:
     (
         model.Session.query(model.Package)
         .filter_by(id=package["id"])
-        .update(
-            {
-                "metadata_created": metadata_created,
-                "metadata_modified": metadata_modified,
-            }
-        )
+        .update(updated_timestamps)
     )


### PR DESCRIPTION
This PR addresses [DAT-548](https://london.atlassian.net/jira/software/c/projects/DAT/issues/DAT-548), and makes some changes to the way a dataset's `last_modified` time is updated.

We only want to update a dataset's last modified time if a resource has changed. Updates to the dataset metadata should not cause the last modified time to be updated.

I've updated the `timestamps.restore_upstream` function (and renamed it to `override`) so that it'll either use the upstream modified & created times if they exist. Otherwise it'll get the dataset's resources and find the most recently modified one, and use that timestamp for the dataset's last_modified timestamp.

The acceptance criteria for this work also require that the timestamp is updated when a resource is deleted. I've added the `IResourceController` plugin interface and implemented `after_resource_delete`, which just updates the package's last_modified time to be the current time.

Note: A resource's URL is considered part of it's metadata. So updating a resource's URL will not update the last modified time. I don't think there's any easy way around this.

