### PR TITLE
Add additional fields to datasets

### DIFF
--- a/ckanext/gla/custom_fields.py
+++ b/ckanext/gla/custom_fields.py
@@ -41,7 +41,22 @@ custom_dataset_fields = {
         toolkit.get_converter("convert_to_extras"),
     ],
     "dataset_boost": [float_validator, toolkit.get_converter("convert_to_extras")],
+    "project_name": [
+        toolkit.get_validator("ignore_missing"),
+        toolkit.get_converter("convert_to_extras")],
+    "project_url": [
+        toolkit.get_validator("ignore_missing"),
+        toolkit.get_validator("url_validator"),
+        toolkit.get_converter("convert_to_extras"),
+    ],
+    "entry_type": [
+        toolkit.get_validator("one_of")(["analysis", "dataset"]),
+        toolkit.get_converter("convert_to_extras")],
+    "search_description": [
+        toolkit.get_validator("ignore_missing"),
+        toolkit.get_converter("convert_to_extras")],
 }
+
 
 
 fields_to_copy = {

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -13,6 +13,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IDatasetForm)
+    plugins.implements(plugins.IFacets)
 
     # IConfigurer
     def update_config(self, config_):
@@ -85,3 +86,9 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
     def package_types(self) -> list[str]:
         return []
+
+    # IFacets
+    def dataset_facets(self, facets_dict, _):
+        facets_dict["project_name"] = toolkit._("Project name")
+        facets_dict["entry_type"] = toolkit._("Type")
+        return facets_dict

--- a/ckanext/gla/templates/package/read.html
+++ b/ckanext/gla/templates/package/read.html
@@ -8,15 +8,6 @@
 {% endblock %}
 
 {% block package_notes %}
-    {% if pkg.archived == 'true' %}
-        <div class="alert alert-info">
-            <i class="fa fa-info-circle"></i>
-            This dataset is no longer actively maintained.
-            {% if pkg.archived_description %}
-                {{h.render_markdown(h.get_translated(pkg, 'archived_description'))}}
-            {% endif %}
-        </div>
-    {% endif %}
     {% set created=h.render_datetime(pkg.metadata_created) %}
     {% set updated=h.render_datetime(pkg.metadata_modified) %}
     <p>
@@ -27,9 +18,34 @@
         <a href={% url_for 'dataset_search', organization=pkg.organization.name %}>{{ pkg.organization.title }}</a>
     </p>
 
-{{ super() }}
-{% endblock %}
+    {% set entry_type=pkg.entry_type.capitalize() if pkg.entry_type else "Dataset" %}
+    <p >
+        Asset type: {{ entry_type }}<br>
+    </p>
+    {% if pkg.archived == 'true' %}
+        <div class="alert alert-info">
+            <i class="fa fa-info-circle"></i>
+            This dataset is no longer actively maintained.
+            {% if pkg.archived_description %}
+                {{h.render_markdown(h.get_translated(pkg, 'archived_description'))}}
+            {% endif %}
+        </div>
+    {% endif %}
+    {% if pkg.project_name %}
+        <p>
+            {% if pkg.project_url %}
+                Project: <a href="{{pkg.project_url}}">{{ pkg.project_name }}</a>
+            {% else %}
+                Project: {{ pkg.project_name }}
+            {% endif %}
+        </p>
+    {% endif %}
+    {% if pkg.search_description %}
+        <p>{{ pkg.search_description }}</p>
+    {% endif %}
+    {{ super() }}
 
+{% endblock %}
 
 {% block package_tags %}
 {% endblock %}

--- a/ckanext/gla/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/gla/templates/package/snippets/package_basic_fields.html
@@ -61,21 +61,62 @@
         classes=["control-medium"])
 }}
 {{
-    form.checkbox("archived", 
+    form.checkbox("archived",
         id="field-dataset-archived",
-        label=_("Archive dataset"), 
+        label=_("Archive dataset"),
         value="true",
         checked=data.archived == 'true',
         classes=["control-medium"])
 }}
 {{
-    form.textarea("archived_description", 
+    form.textarea("archived_description",
         id="field-dataset-archived-desc",
-        label=_("Reason for archiving"), 
+        label=_("Reason for archiving"),
         value=data.archived_description,
         placeholder=_("Reason for archiving"),
         error=errors.archived_description,
         classes=["control-medium"])
 }}
+
+{{
+    form.input("project_name",
+        id="field-project-name",
+        label=_("Project name"),
+        value=data.project_name,
+        error=errors.project_name,
+        classes=["control-medium"])
+}}
+
+{{
+    form.input("project_url",
+        id="field-project-url",
+        type="url",
+        label=_("Project url"),
+        value=data.project_url,
+        error=errors.project_url,
+        classes=["control-medium"])
+}}
+{{
+    form.select("entry_type",
+        id="field-entry-type",
+        label=_("Type"),
+        options=[{"value": "dataset", "text": "Dataset"}, {"value": "analysis", "text": "Analysis"}],
+        selected=data.entry_type if data.entry_type else "dataset",
+        is_required=true,
+        classes=["control-medium"],
+        error=errors.entry_type)
+
+}}
+
+{{
+    form.textarea("search_description",
+        id="field-search-desc",
+        label=_("Search description"),
+        value=data.search_description,
+        error=errors.search_description,
+        classes=["control-medium"])
+}}
+
+
 
 {% endblock %}


### PR DESCRIPTION
Adds the following fields to the dataset edit form and dataset view page:

- project name
- project url
- entry type (dataset or analysis - default is dataset)
- search description

Allows you to filter the search by either project name or entry type.

This does not complete all the criteria for DAT-543 because:

* Harvested datasets don't have a value for entry type as they are not added via the form. It's not straightforward to make the search filter look for "either x or null" in the field, so we will have to add the default to the harvester code.

* We don't have the harvest source field required. This will need to be added seperately as it's a change to the harvester, not the dataset schema.

* I have not added any fields to the resources

* The dataset page UI leaves something to be desired