### PR TITLE
Add harvest source title to filters

### DIFF
--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -79,6 +79,14 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
                 toolkit.get_validator("ignore_missing"),
             ]
             for field in custom_fields.custom_dataset_fields.keys()})
+        schema.update({
+            "harvest_source_title":
+            [
+                toolkit.get_converter("convert_from_extras"),
+                toolkit.get_validator("ignore_missing"),
+            ]
+
+        })
         return schema
 
     def is_fallback(self):
@@ -91,4 +99,5 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     def dataset_facets(self, facets_dict, _):
         facets_dict["project_name"] = toolkit._("Project name")
         facets_dict["entry_type"] = toolkit._("Type")
+        facets_dict["harvest_source_title"] = toolkit._("Source")
         return facets_dict


### PR DESCRIPTION
Adds the harvest_source_title field to the datasets (it's already there in 'extras' but I've now converted it to a top-level field) and enables search filtering by it.