### PR TITLE
Remove the GLA Crisis Communication script

### DIFF
--- a/ckanext/gla/templates/base.html
+++ b/ckanext/gla/templates/base.html
@@ -58,7 +58,6 @@ to avoid spamming GA during dev work #}
         };
         CookieControl.load( config );
     </script>
-    <script type="text/javascript" src="https://www.london.gov.uk/modules/custom/lgov/gla_crisis_communication/gla-crisis-communication/dist/gla_crisis_communication.js"></script>
 {% endif %}
 {{ super() }}
 {% endblock %}


### PR DESCRIPTION
As requested in [DAT-556](https://london.atlassian.net/browse/DAT-556), there are some issues with the crisis communications script that are producing errors in the console. 
It sounds like it's not essential that we use this script at the moment, so this commit removes it.