### PR TITLE
Update package_item to follow DAT-549

### DIFF
--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -1375,6 +1375,10 @@ li.dataset-item {
     align-items: center;
 }
 
+.dataset-last-updated {
+    flex: 0 0 auto;
+}
+
 .dataset-subsection {
     margin-top: 20px;
     margin-bottom: 20px;

--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -1355,8 +1355,12 @@ li.dataset-item {
 }
 
 .dataset-source {
-    margin: 10px 0 0 0;
     display: block;
+}
+
+.dataset-notes {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
 }
 
 .user-image {
@@ -1368,7 +1372,6 @@ li.dataset-item {
     display: flex;
     justify-content: space-between;
     gap: 20px;
-    margin-bottom: 10px;
     align-items: center;
 }
 

--- a/ckanext/gla/templates/snippets/package_item.html
+++ b/ckanext/gla/templates/snippets/package_item.html
@@ -95,7 +95,7 @@ Example:
       </h2>
       
       {% if last_updated %}
-        <div>Updated {{h.localised_nice_date(h.date_str_to_datetime(last_updated))}}</div>
+        <div class="dataset-last-updated">Updated {{h.localised_nice_date(h.date_str_to_datetime(last_updated))}}</div>
       {% endif %}
 
     </div>

--- a/ckanext/gla/templates/snippets/package_item.html
+++ b/ckanext/gla/templates/snippets/package_item.html
@@ -11,8 +11,25 @@ Example:
 
 #}
 {% set title = package.title or package.name %}
-{% set notes = h.markdown_extract(package.notes, extract_length=180) %}
+{% set notes = h.markdown_extract(package.search_description, extract_length=0) %}
+{% if notes|length == 0 %}
+  {% set notes = h.markdown_extract(package.notes, extract_length=180) %}
+{% endif%}
 {% set last_updated = h.last_updated(package) %}
+
+{% set resources_formats = h.dict_list_reduce(package.resources, 'format')%}
+
+{# Workaround in case harvest_source_title doesn't get pulled out of extras #}
+{# variables set inside for loops dont exist outside the loop: https://jinja.palletsprojects.com/en/3.0.x/templates/#assignments  #} 
+{% set ns = namespace(harvest_source_title=package.harvest_source_title) %}
+{% if harvest_source_title|length == 0 %}
+  {% for extra in package.extras %}
+    {% if extra['key'] == "harvest_source_title" %}
+     {% set ns.harvest_source_title = extra['value'] %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
 
 {% block package_item %}
 {% if package.get('type','').startswith('showcase') %}
@@ -76,27 +93,34 @@ Example:
         {{ h.popular('recent views', package.tracking_summary.recent, min=10) if package.tracking_summary }}
         {% endblock %}
       </h2>
-      <span class="small-follow-button">
-        {{ h.follow_button('dataset', package.id) }}
-      </span>
+      
+      {% if last_updated %}
+        <div>Updated {{h.localised_nice_date(h.date_str_to_datetime(last_updated))}}</div>
+      {% endif %}
 
     </div>
+    <div class="dataset-source">{{package.organization.title}}{% if ns.harvest_source_title %}, hosted by {{ns.harvest_source_title}}{% endif %}</div>
     {% endblock %}
     {% block notes %}
     {% if notes %}
-    <div>{{ notes|urlize }}</div>
+    <div class="dataset-notes">{{ notes|urlize }}</div>
     {% else %}
     <p class="empty">{{ h.humanize_entity_type('package', package.type, 'no description') or _("There is no
             description for this dataset") }}</p>
     {% endif %}
     {% endblock %}
+    <div>
+      {% if package.entry_type%}
+        {{package.entry_type|capitalize}}
+      {% else %}
+        Dataset
+      {% endif %}
+      {% if resources_formats|length > 0 %} | {{resources_formats|join(", ") | lower}} {% endif %}
+    </div>
   </div>
 
-  <span class="dataset-source">Source: <strong>{{package.organization.title}}</strong></span>
 
-  {% if last_updated %}
-  <div>Updated {{h.localised_nice_date(h.date_str_to_datetime(last_updated))}}</div>
-  {% endif %}
+  
   {# {% block resources %}
     {% if package.resources and not hide_resources %}
     {% block resources_outer %}


### PR DESCRIPTION
Various small changes to package_item so that the design matches what was requested in [DAT-549](https://london.atlassian.net/browse/DAT-549).

- Use the `search_description` if it's available, otherwise fall back to the truncated main description.
- Move `last updated` time to the top.
- Add "hosted by <harvest source>" under the dataset title, using the `harvest_source_title`.
- Add the dataset `entry_type` (default to `Dataset` if not present) and add the available resource formats.

The only issue was the `harvest_source_title`, which for some reason wasn't always being extracted from the package.extras into its own key. I've come up with a hacky workaround using jinja2's namespaces (see the `Scoping Behaviour` section in the [Assignments](https://jinja.palletsprojects.com/en/2.11.x/templates/#assignments) section of the docs) and looping over the extras, in case the convert_from_extras doesn't work when deployed.