### PR TITLE
Fix server error on organisation page

### DIFF
--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -105,3 +105,6 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         facets_dict["entry_type"] = toolkit._("Type")
         facets_dict["harvest_source_title"] = toolkit._("Source")
         return facets_dict
+
+    def organization_facets(self, facets_dict, *args):
+        return facets_dict


### PR DESCRIPTION
When I implemented the IFacets interface for the dataset search filters, I forgot to implement the corresponding funciton for organisations. Even though we don't have search filters on the organisations page, and plan to remove that page anyway, CKAN needs it to be implemented.