### PR TITLE
DAT-542 Restrict search sorting options

### DIFF
--- a/ckanext/gla/templates/snippets/search_form.html
+++ b/ckanext/gla/templates/snippets/search_form.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 
 {% set placeholder = 'Please enter a search term e.g. environment' if type == 'dataset' else 'Search {type}s...'.format(type=type) %}
-{% set sorting = sorting if sorting else [(_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
+{% set sorting = [(_('Relevance'), 'score desc'), (_('Last Modified'), 'metadata_modified desc')] %}
 {% set search_class = search_class if search_class else 'search-giant' %}
 {% set no_bottom_border = no_bottom_border if no_bottom_border else false %}
 {% set form_id = form_id if form_id else false %}


### PR DESCRIPTION
Only two options to sort datasets: relevance (default) and most recently modified.