### PR TITLE
DAT-574 - Remove API link from search results

### DIFF
--- a/ckanext/gla/templates/package/search.html
+++ b/ckanext/gla/templates/package/search.html
@@ -1,0 +1,4 @@
+{% ckan_extends %}
+
+{% block package_search_results_api %}
+{% endblock %}


### PR DESCRIPTION
Removes the section below the search results that says you can access the data via API.