### PR TITLE
Dat 582 reinstate follow

### DIFF
--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -1369,6 +1369,10 @@ li.dataset-item {
     margin-left: 10px;
 }
 
+.large-follow-button {
+    display: flex;
+    float: right;
+}
 .favs-block ul.dataset-list {
     margin: 0;
 }

--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -1360,12 +1360,13 @@ li.dataset-item {
 }
 
 .small-follow-button>a {
-    font-size: 1rem;
-    padding: 12px 10px;
+    font-size: .8em;
+    padding: 10px 8px;
     border: 2px solid black;
     box-shadow: none;
     background: transparent;
     white-space: nowrap;
+    margin-left: 10px;
 }
 
 .favs-block ul.dataset-list {

--- a/ckanext/gla/templates/package/read.html
+++ b/ckanext/gla/templates/package/read.html
@@ -1,7 +1,11 @@
 {% ckan_extends %}
 
 {% block page_heading %}
+
     {{ super() }}
+    <span class="large-follow-button">
+        {{ h.follow_button('dataset', pkg.id) }}
+    </span>
     {% if pkg.archived == 'true' %}
         [{{_('Archived')}}]
     {% endif %}

--- a/ckanext/gla/templates/snippets/package_item.html
+++ b/ckanext/gla/templates/snippets/package_item.html
@@ -93,10 +93,15 @@ Example:
         {{ h.popular('recent views', package.tracking_summary.recent, min=10) if package.tracking_summary }}
         {% endblock %}
       </h2>
-      
-      {% if last_updated %}
-        <div class="dataset-last-updated gla-informational">Updated {{h.localised_nice_date(h.date_str_to_datetime(last_updated))}}</div>
-      {% endif %}
+      <div class="dataset-last-updated gla-informational">
+          {% if last_updated %}
+            Updated {{h.localised_nice_date(h.date_str_to_datetime(last_updated))}}
+          {% endif %}
+          <span class="small-follow-button">
+              {{ h.follow_button('dataset', package.id) }}
+          </span>
+      </div>
+
 
     </div>
     <div class="dataset-source gla-informational">Published by {{package.organization.title}}{% if ns.harvest_source_title %}, hosted by {{ns.harvest_source_title}}{% endif %}</div>


### PR DESCRIPTION
When adding the updated date to the search result items, we removed the 'follow' button
When removing the sidebar from the dataset page, we also removed the 'follow' button (though it didn't actually work in any case)

This adds it back to both pages