### PR TITLE
Remove groups and showcase tabs

### DIFF
--- a/ckanext/gla/templates/package/read_base.html
+++ b/ckanext/gla/templates/package/read_base.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{% block content_primary_nav %}
+{{ h.build_nav_icon(dataset_type ~ '.read', _('Dataset'),  id=pkg.name, icon='sitemap') }}
+{{ h.build_nav_icon('activity.package_activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name, icon='clock') }}
+{% endblock %}


### PR DESCRIPTION
This PR addresses [DAT-578](https://london.atlassian.net/browse/DAT-578).

The `read_base` template is overridden in both the showcase and activity extensions. The `dataset_type` is added by the base template, and `activity.package_activity` is added by the activity plugin. The showcase extension also tries to add its own tab.

Because our extension is loaded first I think it then doesn't also pull in the changes from the other extensions. But that means we need to explicitly include the activity tab, because it no longer gets added by the activity extension.

The CKAN plugin system is still a mystery to me.

Note: This is a new template file that we've not used in our extension before, so you'll need to re-built your local Docker container to get this to show up.