### PR TITLE
DAT-583 Fix links in user profile edit footer

### DIFF
--- a/ckanext/gla/templates/user/edit_user_form.html
+++ b/ckanext/gla/templates/user/edit_user_form.html
@@ -17,8 +17,8 @@
       <div class="delete-account">
           <h6>Delete account</h6>
           <p>
-              If you wish to delete your account, please <a href="mailto:admin@todo.com">email the site administrator</a> from the email address associated with your acocunt.
-              All personal data will be removed from our systems upon request in accordance with GDPR regulation. Further information can be found in the <a href="/privacy-policy">Privacy Policy</a>.
+              If you wish to delete your account, please <a href="mailto:datastore@london.gov.uk">email the site administrator</a> from the email address associated with your acocunt.
+              All personal data will be removed from our systems upon request in accordance with GDPR regulation. Further information can be found in the <a href="/about/privacy-policy">Privacy Policy</a>.
           </p>
       </div>
 {% endblock %}


### PR DESCRIPTION
In the section with instructions for users wishing to delete their accounts:

- Update link to privacy policy
- Add real contact email