### PR TITLE
Change page title for search and dataset pages

### DIFF
--- a/ckanext/gla/templates/base.html
+++ b/ckanext/gla/templates/base.html
@@ -1,5 +1,13 @@
 {% ckan_extends %}
 
+{% set title = h.get_site_title(request) %}
+{% block title %}
+{% if title %}
+    {{ title }}
+{% else %}
+    {{ super() }}
+{% endif %}
+{% endblock %}
 {% block custom_styles %}
 <link rel="stylesheet" href="/gla.css" />
 {% endblock %}


### PR DESCRIPTION
Search page, no query: "Search - Data for London"
Search page, query: "<query> - Data for London"
Dataset/resource page: "<dataset name> - Data for London"