### PR TITLE
Resource page 'additional information' table.

### DIFF
--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -1514,38 +1514,38 @@ a:hover {
 
 /* More info table */
 
-#additional-info div {
+.additional-info div {
     width: 100%;
     display: flex;
 }
 
-#additional-info dl {
+.additional-info dl {
     margin-top: 1rem;
     border: 1px solid var(--bs-gray-200);
 }
 
-#additional-info dt {
+.additional-info dt {
     float: left;
     width: 30%;
 }
 
-#additional-info dd {
+.additional-info dd {
     clear: right;
     float: right;
     width: 70%;
 }
 
-#additional-info dt,
+.additional-info dt,
 dd {
     padding: 0.5rem 0.5rem;
     margin: 0;
 }
 
-#additional-info>dl>div>dt {
+.additional-info>dl>div>dt {
     background-color: #000000ba;
     color: var(--bs-gray-100);
 }
 
-#additional-info>dl>div:nth-of-type(odd) {
+.additional-info>dl>div:nth-of-type(odd) {
     box-shadow: inset 0 0 0 9999px #00000014;
 }

--- a/ckanext/gla/templates/package/resource_read.html
+++ b/ckanext/gla/templates/package/resource_read.html
@@ -28,3 +28,34 @@
     {% endblock %}
     </ul>
 {% endblock %}
+
+
+{% block resource_additional_information_inner %}
+
+    <!--- Set up the information to show in the additional info table ---!>
+
+    <!--- We will use the created date for both modified dates if they are not present ---!>
+    {% set data_modified=res.created %}
+    {% if res.last_modified %}
+        {% set data_modified=res.last_modified %}
+    {% endif %}
+
+    {% set metadata_modified=res.created %}
+    {% if res.metadata_modified %}
+        {% set metadata_modified=res.metadata_modified %}
+    {% endif %}
+
+    {% set format= res.format or res.mimetype_inner or res.mimetype %}
+
+        <div class="module-content">
+
+            {% snippet "package/snippets/additional_info_table.html",
+            table_rows=[{"label": _('Data last updated'), "datetime": data_modified},
+                        {"label": _('Metadata last updated'), "datetime": metadata_modified},
+                        {"label": _('Created'), "datetime": res.created},
+                        {"label": _('Format'), "text": format},
+                        {"label": _('License'), "text": pkg.license_title, "href": pkg.license_url},
+                        {"label": _('Size'), "text": h.SI_number_span(res.size) if res.size }]
+            %}
+        </div>
+        {% endblock %}

--- a/ckanext/gla/templates/package/snippets/additional_info.html
+++ b/ckanext/gla/templates/package/snippets/additional_info.html
@@ -1,108 +1,45 @@
+<!--- set up the information to show in the 'additional info' table. If the values are not present, the row is not shown---!>
+{% if pkg_dict.author_email %}
+    {% set author_text = pkg_dict.author_email %}
+    {% set author_mailto = "mailto:" + pkg_dict.author_email %}
+{% endif %}
+{% if pkg_dict.author %}
+    {% set author_text = pkg_dict.author %}
+{% endif %}
+
+{% if pkg_dict.maintainer_email %}
+    {% set maintainer_text = pkg_dict.maintainer_email %}
+    {% set maintainer_mailto = "mailto:" + pkg_dict.maintainer_email %}
+{% endif %}
+{% if pkg_dict.maintainer %}
+    {% set maintainer_text = pkg_dict.maintainer %}
+{% endif %}
+
+{% if h.check_access('package_update',{'id':pkg_dict.id}) %}
+    {% set pkg_state = _(pkg_dict.state) %}
+{% endif %}
+
+
+<!--- we have to introduce a namespace to set the upstream_url variable as regular variables are scoped only within the loop---!>
+{% set extras = namespace(upstream_url=none) %}
+{% for extra in pkg_dict.extras %}
+    {% if extra.key == "upstream_url" %}
+        {% set extras.upstream_url=extra.value %}
+    {% endif %}
+{% endfor %}
+
 <section id="additional-info">
-  <dl>
-      {% block package_additional_info %}
-        {% if pkg_dict.url %}
-        <div>
-            <dt class="dataset-label">{{ _('Source') }}</dt>
-            {% if h.is_url(pkg_dict.url) %}
-              <dd class="dataset-details" property="foaf:homepage">
-                <a href="{{ pkg_dict.url }}" rel="foaf:homepage" target="_blank">
-                  {{ pkg_dict.url }}
-                </a>
-              </dd>
-            {% else %}
-              <dd class="dataset-details" property="foaf:homepage">{{ pkg_dict.url }}</dd>
-            {% endif %}
-        </div>
-        {% endif %}
-
-        {% if pkg_dict.author_email %}
-        <div>
-            <dt class="dataset-label">{{ _("Author") }}</dt>
-            {% if pkg_dict.author %}
-              <dd class="dataset-details" property="dc:creator">{{ h.mail_to(email_address=pkg_dict.author_email, name=pkg_dict.author) }}</dd>
-            {% else %}
-              <dd class="dataset-details" property="dc:creator">{{ h.mail_to(email_address=pkg_dict.author_email, name=pkg_dict.author_email) }}</dd>
-            {% endif %}
-        </div>
-        {% elif pkg_dict.author %}
-          
-        <div>
-            <dt class="dataset-label">{{ _("Author") }}</dt>
-            <dd class="dataset-details" property="dc:creator">{{ pkg_dict.author }}</dd>
-        </div>
-        {% endif %}
-
-        {% if pkg_dict.maintainer_email %}
-        <div>
-            <dt class="dataset-label">{{ _('Maintainer') }}</dt>
-            {% if pkg_dict.maintainer %}
-              <dd class="dataset-details" property="dc:contributor">{{ h.mail_to(email_address=pkg_dict.maintainer_email, name=pkg_dict.maintainer) }}</dd>
-            {% else %}
-              <dd class="dataset-details" property="dc:contributor">{{ h.mail_to(email_address=pkg_dict.maintainer_email, name=pkg_dict.maintainer_email) }}</dd>
-            {% endif %}
-        </div>
-        {% elif pkg_dict.maintainer %}
-        <div>
-            <dt class="dataset-label">{{ _('Maintainer') }}</dt>
-            <dd class="dataset-details" property="dc:contributor">{{ pkg_dict.maintainer }}</dd>
-        </div>
-        {% endif %}
-
-        {% if pkg_dict.version %}
-          
-        <div>
-            <dt class="dataset-label">{{ _("Version") }}</dt>
-            <dd class="dataset-details">{{ pkg_dict.version }}</dd>
-        </div>
-        {% endif %}
-
-        {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
-          
-        <div>
-            <dt class="dataset-label">{{ _("State") }}</dt>
-            <dd class="dataset-details">{{ _(pkg_dict.state) }}</dd>
-        </div>
-        {% endif %}
-        {% if pkg_dict.metadata_modified %}
-        <div>
-            <dt class="dataset-label">{{ _("Last Updated") }}</dt>
-            <dd class="dataset-details">
-                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_modified %}
-            </dd>
-        </div>
-        {% endif %}
-        {% if pkg_dict.metadata_created %}
-         <div> 
-            <dt class="dataset-label">{{ _("Created") }}</dt>
-
-            <dd class="dataset-details">
-                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_created %}
-            </dd>
-         </div>
-        {% endif %}
-
-        {% block extras %}
-        {% for extra in pkg_dict.extras %}
-          {% if extra.key == "upstream_url" %}
-            <div>
-              <dt class="dataset-label">Upstream URL</dt>
-              <dd class="dataset-details">
-                <a href="{{ extra.value }}">{{ extra.value }}</a>
-              </dd>
-            </div>
-          {% endif %}
-        {% endfor %}
-        {% if pkg_dict.data_quality %}
-        <div>
-            <dt class="dataset-label">Data Quality</dt>
-            <dd class="dataset-details">{{ pkg_dict.data_quality }}</dd>
-        </div>
-        {% endif %}
-        {% endblock %}
-
-      {% endblock %}
-  </dl>
+{% snippet "package/snippets/additional_info_table.html",
+table_rows=[{"label":  _('Source') , "text": pkg_dict.url, "href": pkg_dict.url},
+            {"label": _('Author'), "text": author_text, "href": author_mailto},
+            {"label": _('Maintainer'), "text": maintainer_text, "href": maintainer_mailto},
+            {"label": _('Version'), "text": pkg_dict.version},
+            {"label": _('State'), "text": pkg_state},
+            {"label": _('Last Updated'), "datetime": pkg_dict.metadata_modified},
+            {"label": _('Created'), "datetime": pkg_dict.metadata_created},
+            {"label": _('Upstream URL'), "text": extras.upstream_url, "href": extras.upstream_url},
+            {"label": 'Data Quality', "text": pkg_dict.data_quality}]
+%}
 </section>
 
 

--- a/ckanext/gla/templates/package/snippets/additional_info_table.html
+++ b/ckanext/gla/templates/package/snippets/additional_info_table.html
@@ -1,0 +1,30 @@
+{#
+
+Renders the 'additional info' table used on the dataset and resource pages as a description list.
+We have replaced the default CKAN version because it was not so screen reader accessible.
+
+Expects the `table_rows` parameter to contain a list of rows to display. Each row has a `label` field,
+which is the field name shown in the left hand column, and a value to show on the right given in either the
+`text` or `datetime` field depending on its type. Optionally, it will link to the URL given by the `href` field.
+#}
+
+<div class="additional-info">
+    <dl>
+        {% for row in table_rows %}
+        {% if row.text or row.datetime %}
+            <div>
+                <dt class="dataset-label">{{ row.label }}</dt>
+                <dd class="dataset-details">
+                    {% if row.datetime %}
+                        {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=row.datetime %}
+                    {% elif row.href %}
+                        <a href="{{ row.href }}" target="_blank">{{ row.text }}</a>
+                    {% else %}
+                        {{ row.text }}
+                    {% endif %}
+                </dd>
+            </div>
+        {% endif %}
+        {% endfor %}
+    </dl>
+</div>


### PR DESCRIPTION
Converts the additional information table on the resource page to use a description list instead of a table, in the same way as commit #7fe97f6a9b16d3be57bb58b15577b6f70fbc14cb did for the dataset page. This removes the 'view more' option and shows the whole table all at once as well as slightly changing the style.

This involved refactoring the template for the dataset page table so a common snippet is used for both pages.

In addition to the change from table to description list, I have made some edits to the information shown in the table for a resource:

* Instead of writing "unknown" in place of missing values, omit the row entirely. This makes it consistent with the dataset page.

* Remove extra fields from the table: we previously had all sorts of extra fields in the expandable part of the table that didn't seem useful, such as the boolean `hasViews` and the index of the resource in the resoucre list. I have changed it so only the file size is retained from this section.