### PR TITLE
Re-add activity plugin javascript

### DIFF
--- a/ckanext/gla/templates/page.html
+++ b/ckanext/gla/templates/page.html
@@ -122,4 +122,5 @@
     {% asset 'base/tracking' %}
   {% endif %}
   {{ super() }}
+  {% asset "ckanext-activity/activity" %}
 {% endblock -%}


### PR DESCRIPTION
**The problem**

On a dataset's activity timeline tab, the selector to filter by activity type has no effect.

**The explanation**

Short answer: the `activity-stream.js` script (from the activity plugin's webassets) is needed for the filter behaviour, but it is not present.

Long answer:

It turns out that plugin inheritance isn't working as I thought. I would expect that calling `super()` in the scripts template block would add the scripts from all plugins but it does not in fact do that - someone already must have noticed this when they added the scripts from CKAN base such as `base/tracking`.

It's not clear from the documentation whether this is by design or not. The adding of a plugin should, intuitively, add the entirety of the plugin code and if this is not the intended behaviour it should be mentioned in the extension guide. Whatever the reason may be, it appears that any and all scripts needed must be included in the `scripts` block regardless of their origin.

**Solution**

Added the webasset from the activity plugin to the scripts block.