### PR TITLE
Show more of facet filter option text

### DIFF
--- a/ckanext/gla/templates/snippets/facet_list.html
+++ b/ckanext/gla/templates/snippets/facet_list.html
@@ -8,7 +8,7 @@
     {% for item in items %}
         {% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
         {% set label = label_function(item) if label_function else item.display_name %}
-        {% set label_truncated = label|truncate(22) if not label_function else label %}
+        {% set label_truncated = label|truncate(30, True) if not label_function else label %}
         {% set count = count_label(item['count']) if count_label else ('%d' % item['count']) %}
         <li class="nav-item {% if item.active %} active{% endif %}">
     <a href="{{ href }}" title="{{ label if label != label_truncated else '' }}">


### PR DESCRIPTION
The text in the search filter options lists (such as organisation names) was being truncated to 22 characters, full words only. This meant that we weren't seeing enough text to know what the filters mean, for example with several organisations shown as "London Borough of..." or "Office for...".

I have now changed it so that:

* We show up to 30 characters (just shy of the maximum number we could show on a single line here)

* Partial words are shown when the 30-character split happens in the middle of the word.