### PR TITLE
Update footer structure

### DIFF
--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -844,7 +844,7 @@ header.module-content.page-header {
     padding: 3rem 0;
 }
 
-.site-footer h4 {
+.site-footer .h4 {
     color: white;
     margin-bottom: 1.25rem;
 }
@@ -862,6 +862,7 @@ header.module-content.page-header {
 }
 
 .site-footer .footer-links ul {
+    column-count: 2;
     border-right: 1px solid var(--t-colors-grey);
 }
 

--- a/ckanext/gla/templates/footer.html
+++ b/ckanext/gla/templates/footer.html
@@ -1,9 +1,9 @@
 <footer class="site-footer">
     <div class="container">
-        <h4>Useful links</h4>
+        <h2 class="h4">Useful links</h2>
       {% block footer_content %}
       <div class="row">
-        <div class="col-md-4 footer-links">
+        <div class="col-md-8 footer-links">
           {% block footer_nav %}
             <ul class="list-unstyled">
                 <li><a href="/about">Contact Us</a></li>
@@ -11,17 +11,12 @@
                 <li><a href="/about/data-quality-standards">Standards</a></li>
                 <li><a href="/about/privacy-policy">Privacy Policy</a></li>
                 <li><a href="/about/privacy-policy" id="gla-cookie-control">Cookie preferences</a></li>
-            </ul>
-          {% endblock %}
-        </div>
-        <div class="col-md-4 footer-links">
-            <ul class="list-unstyled">
-                
                 <li><a href="/about/frequently-asked-questions">FAQs</a></li>
                 <li><a href="/about/accessibility">Accessibility</a></li>
                 <li><a href="/about/terms-and-conditions">Terms and Conditions</a></li>
                 <li><a href="/about/credits">Credits</a></li>
             </ul>
+          {% endblock %}
         </div>
         <div class="col-md-4 attribution">
           {% block footer_attribution %}


### PR DESCRIPTION
This PR addresses [DAT-419](https://london.atlassian.net/browse/DAT-419).
Results of accessibility testing required that the footer header should be a `h2` element and the footer links should be in one list rather than 2.

Only minor changes to the template and css were needed to fix this.
`column-count: 2` was suggested by the accessibility tester and looks Ok.

And I've added a `.h4` class to the `h2` so that it looks exactly the same as before.

![image](https://github.com/GreaterLondonAuthority/dfl-ckanext/assets/1217533/56a51050-ee87-414d-a40e-6d984d3fec12)
