### PR TITLE
Update error colours

### DIFF
--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -1498,8 +1498,28 @@ div#followee-filter {
 
 .alert-info {
     color: #874006;
-    border-color: #fd7e14ff;
-    background-color: #fd7e1411;
+    border-color: #fd7e14;
+    background-color: #FFF6F0;
+}
+
+.alert-error {
+    color: #8B0000;
+    background-color: #f8f0f0;
+    border-color: #c6898b;
+}
+
+.alert-danger a {
+    color: #8B0000;
+}
+
+.error-inline {
+    color: #8B0000;
+    margin: 0.5rem;
+}
+
+.resource-view-filters .resource-view-remove-filter {
+    cursor: pointer;
+    color: #8B0000;
 }
 
 .alert-info a,


### PR DESCRIPTION
# Error colours
This PR addresses [DAT-435](https://london.atlassian.net/browse/DAT-435), and updates some text colours to improve their contrast and satisfy WCAG 2.1.

## Changes
Copied over the `alert-error`, `alert-danger`, `error-inline` and `resource-view` CSS from CKAN's [main.css](https://github.com/ckan/ckan/blob/master/ckan/public/base/css/main.css) file and updated the text colour to `#8B0000` as suggested in the Jira ticket. 

Also updated the `alert-info` colours to slightly increase the contrast.