### PR TITLE
Fix html tag language

### DIFF
--- a/ckanext/gla/views.py
+++ b/ckanext/gla/views.py
@@ -182,5 +182,13 @@ undelete.add_url_rule(
 )
 
 
+lang_redirect = Blueprint("lang_redirect", __name__)
+
+lang_redirect.add_url_rule(
+    "/api/i18n/en-GB",
+    view_func=lambda: tk.redirect_to("/api/i18n/en_GB"),
+    endpoint="lang_redirect"
+)
+
 def get_blueprints():
-    return [favourites, users, about, search_log_download, undelete]
+    return [favourites, users, about, search_log_download, undelete, lang_redirect]


### PR DESCRIPTION
Commit ea0fc74ecf891c504288effe37c35410276fbf84 was a seemingly innocuous change to the "lang" attribute of the html tag, but it broke at least one javascript component (the search order selector) and probably more
 because CKAN's base js uses the language _in the html tag_ rather than
the language from the configuration to find the correct translation file for a language at <host>/api/i18n/<language-code>. Because we didn't install a language called en-GB, it was unable to find /api/i18n/en-GB. The code for the select itself doesn't need anything translated, but the base javascript module fails to initialise if this file can't be found.

To resolve this, I have added a redirect from /api/i18n/en-GB to /api/i18n/en_GB.