### PR TITLE
DAT-427 - Change sort order selector to links

### DIFF
--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -1296,12 +1296,11 @@ p.accordion__empty.empty {
         display: flex;
         justify-content: space-between;
         align-items: flex-end;
-        margin-bottom: 30px;
     }
 }
 
 @media (min-width: 768px) {
-    .search-form .control-order-by {
+    .search-form {
         float: none;
         margin-left: 0;
         width: auto;
@@ -1309,6 +1308,18 @@ p.accordion__empty.empty {
     }
 }
 
+.search-header__order {
+    float: right;
+    margin-bottom: 15px;
+}
+.search-header__order a {
+    font-size: 14px;
+}
+
+.search-header__order a.selected {
+    font-weight: bold;
+    color: var(--t-colors-pink);
+}
 h2.dataset-heading {
     font-size: 1.333rem;
 }

--- a/ckanext/gla/templates/snippets/search_form.html
+++ b/ckanext/gla/templates/snippets/search_form.html
@@ -24,10 +24,11 @@
         <label style="pointer-events:none;" id="order-by-label">{{ _('Order by') }}</label>
               {% for label, value in sorting %}
                 {% if label and value %}
+                    {% set is_selected = sorting_selected.split(",")[0] == value %}
                     {% if loop.index != 1 %} |{% endif %}
                     <a href={{ h.remove_url_param("sort", replace=value)}}
                         class="
-                        {% if sorting_selected == value %} selected {% endif %}
+                        {% if is_selected %} selected {% endif %}
                         "
                         aria-labelledby="order-by-label"
                     >{{ label }}</a>

--- a/ckanext/gla/templates/snippets/search_form.html
+++ b/ckanext/gla/templates/snippets/search_form.html
@@ -16,27 +16,28 @@
         <h2>Error</h2>
         {% endif %}
         {% endblock %}
+        </div>
     </div>
     <div class="search-header__order">
         {% block search_sortby %}
         {% if sorting %}
-          <div class="form-group control-order-by">
-            <label for="field-order-by">{{ _('Order by') }}</label>
-            <select id="field-order-by" name="sort" class="form-control form-select">
+        <label style="pointer-events:none;" id="order-by-label">{{ _('Order by') }}</label>
               {% for label, value in sorting %}
                 {% if label and value %}
-                  <option value="{{ value }}"{% if sorting_selected == value %} selected="selected"{% endif %}>{{ label }}</option>
+                    {% if loop.index != 1 %}|{% endif %}
+                    <a href={{ h.remove_url_param("sort", replace=value)}}
+                        class="
+                        {% if sorting_selected == value %} selected {% endif %}
+                        "
+                        aria-labelledby="order-by-label"
+                    >
+                        {{ label }}
+                    </a>
                 {% endif %}
               {% endfor %}
-            </select>
-            {% block search_sortby_button %}
-            <button class="btn btn-default js-hide" type="submit">{{ _('Go') }}</button>
-            {% endblock %}
-          </div>
         {% endif %}
       {% endblock %}
     </div>
-</div>
 
 {% block search_input %}
 <div class="input-group search-input-group">

--- a/ckanext/gla/templates/snippets/search_form.html
+++ b/ckanext/gla/templates/snippets/search_form.html
@@ -24,15 +24,13 @@
         <label style="pointer-events:none;" id="order-by-label">{{ _('Order by') }}</label>
               {% for label, value in sorting %}
                 {% if label and value %}
-                    {% if loop.index != 1 %}|{% endif %}
+                    {% if loop.index != 1 %} |{% endif %}
                     <a href={{ h.remove_url_param("sort", replace=value)}}
                         class="
                         {% if sorting_selected == value %} selected {% endif %}
                         "
                         aria-labelledby="order-by-label"
-                    >
-                        {{ label }}
-                    </a>
+                    >{{ label }}</a>
                 {% endif %}
               {% endfor %}
         {% endif %}


### PR DESCRIPTION
When tab-selecting the "order by" selector on the search page, the page is automatically reloaded when you select an option. We want users to be able to see the options without applying them so I have changed the selector to a list of links, with the currently active sort order highlighted in pink.