### PR TITLE
Make 'new user' form screen reader accessible

### DIFF
--- a/ckanext/gla/templates/user/new_user_form.html
+++ b/ckanext/gla/templates/user/new_user_form.html
@@ -1,11 +1,75 @@
-{% ckan_extends %}
-{% block required_core_fields %}
-    {{ form.input("name", id="field-username", label=_("Username"), placeholder=_("username"), value=data.name, error=errors.name, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'username'}, is_required=True) }}
-    {{ form.input("fullname", id="field-fullname", label=_("Full Name"), placeholder=_("Joe Bloggs"), value=data.fullname, error=errors.fullname, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'name'}) }}
-    {{ form.input("email", id="field-email", label=_("Email"), type="email", placeholder=_("joe@example.com"), value=data.email, error=errors.email, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'email'}, is_required=True) }}
-    {{ form.input("password1", id="field-password", label=_("Password"), type="password", placeholder="••••••••", value=data.password1, error=errors.password1, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'new-password'}, is_required=True) }}
-    {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", placeholder="••••••••", value=data.password2, error=errors.password2, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'new-password'}, is_required=True) }}
-{% endblock %}
+{% import "macros/form.html" as form %}
 
-{% block optional_core_fields %}
+{% block form %}
+  <form id="user-register-form" action="" method="post" enctype="multipart/form-data">
+
+    {{ h.csrf_input() }}
+    {{ form.required_message() }}
+    {{ form.errors(error_summary) }}
+
+    {% block core_fields %}
+      {% block required_core_fields %}
+        {{ form.input("name",
+                    id="field-username",
+                    label=_("Username"),
+                    placeholder=_("username"),
+                    value=data.name,
+                    error=errors.name,
+                    classes=["control-medium"],
+                    attrs={'class': 'form-control', 'autocomplete': 'username', 'required': 'true'},
+                    is_required=True) }}
+        {{ form.input("fullname",
+                    id="field-fullname",
+                    label=_("Full Name"),
+                    placeholder=_("Joe Bloggs"),
+                    value=data.fullname,
+                    error=errors.fullname,
+                    classes=["control-medium"],
+                    attrs={'class': 'form-control', 'autocomplete': 'name'}) }}
+        {{ form.input("email",
+                    id="field-email",
+                    label=_("Email"),
+                    type="email",
+                    placeholder=_("joe@example.com"),
+                    value=data.email,
+                    error=errors.email,
+                    classes=["control-medium"],
+                    attrs={'class': 'form-control', 'autocomplete': 'email', 'required': 'true'},
+                    is_required=True) }}
+        {{ form.input("password1",
+                    id="field-password",
+                    label=_("Password"),
+                    type="password",
+                    placeholder="••••••••",
+                    value=data.password1,
+                    error=errors.password1,
+                    classes=["control-medium"],
+                    attrs={'class': 'form-control', 'autocomplete': 'new-password', 'required': 'true'},
+                    is_required=True) }}
+        {{ form.input("password2",
+                    id="field-confirm-password",
+                    label=_("Confirm"),
+                    type="password",
+                    placeholder="••••••••",
+                    value=data.password2,
+                    error=errors.password2,
+                    classes=["control-medium"],
+                    attrs={'class': 'form-control', 'autocomplete': 'new-password', 'required': 'true'},
+                    is_required=True) }}
+      {% endblock %}
+
+    {% endblock %}
+
+    {% block captcha %}
+      {% if g.recaptcha_publickey %}
+        {% snippet "user/snippets/recaptcha.html", public_key=g.recaptcha_publickey %}
+      {% endif %}
+    {% endblock %}
+
+    <div class="form-actions">
+      {% block form_actions %}
+      <button class="btn btn-primary" type="submit" name="save">{{ _("Create Account") }}</button>
+      {% endblock %}
+    </div>
+  </form>
 {% endblock %}


### PR DESCRIPTION
* Move the message that indicates asterisked fields are required to the top of the form, just below the header

* Add `required` attribute to all required form elements