### PR TITLE
Remove brown highlighting of hover links

### DIFF
--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -1538,8 +1538,7 @@ div#followee-filter {
     color: var(--t-colors-dark-red);
 }
 
-.alert-info a,
-a:hover {
+.alert-info a {
     color: #874006;
     text-decoration-color: #874006;
 }


### PR DESCRIPTION
When setting the colours for the archived description panel (the alert-info class),
I accidentally applied the brown text rule to all links in the hover state across the site with a small typo.