### PR TITLE
DAT-551 Add custom fields to resource

### DIFF
--- a/ckanext/gla/custom_fields.py
+++ b/ckanext/gla/custom_fields.py
@@ -3,6 +3,7 @@ from ckan.lib.navl.dictization_functions import Invalid
 import requests
 import json
 import os
+from datetime import datetime
 
 
 solr_endpoint = os.getenv("CKAN_SOLR_URL")
@@ -57,7 +58,41 @@ custom_dataset_fields = {
         toolkit.get_converter("convert_to_extras")],
 }
 
+def date_validator(date_string):
+    if date_string == "":
+        return None
+    try:
+        parsed = datetime.strptime(date_string, "%Y-%m-%d")
+        return date_string
+    except:
+        raise Invalid("Must be a date of format YYYY-MM-DD")
 
+custom_resource_fields = {
+    "http_status": [
+        toolkit.get_validator("ignore_missing")
+    ],
+    "last_check": [
+        toolkit.get_validator("ignore_missing"),
+        date_validator
+    ],
+    "resource_hash": [
+        toolkit.get_validator("ignore_missing")
+    ],
+    "mime_type": [
+        toolkit.get_validator("ignore_missing")
+    ],
+    "resource_category": [
+        toolkit.get_validator("ignore_missing")
+    ],
+    "validity_start": [
+        toolkit.get_validator("ignore_missing"),
+        date_validator
+    ],
+    "validity_end": [
+        toolkit.get_validator("ignore_missing"),
+        date_validator
+    ],
+}
 
 fields_to_copy = {
     "extras_data_quality": {"type": "int", "name": "copy_data_quality"},

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -69,11 +69,13 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     def create_package_schema(self) -> Schema:
         schema = super(GlaPlugin, self).create_package_schema()
         schema.update(custom_fields.custom_dataset_fields)
+        schema["resources"].update(custom_fields.custom_resource_fields)
         return schema
 
     def update_package_schema(self) -> Schema:
         schema = super(GlaPlugin, self).update_package_schema()
         schema.update(custom_fields.custom_dataset_fields)
+        schema["resources"].update(custom_fields.custom_resource_fields)
         return schema
 
     def show_package_schema(self) -> Schema:
@@ -92,6 +94,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             ]
 
         })
+        schema["resources"].update(custom_fields.custom_resource_fields)
         return schema
 
     def is_fallback(self):

--- a/ckanext/gla/templates/package/resource_read.html
+++ b/ckanext/gla/templates/package/resource_read.html
@@ -55,7 +55,14 @@
                         {"label": _('Created'), "datetime": res.created},
                         {"label": _('Format'), "text": format},
                         {"label": _('License'), "text": pkg.license_title, "href": pkg.license_url},
-                        {"label": _('Size'), "text": h.SI_number_span(res.size) if res.size }]
+                        {"label": _('Size'), "text": h.SI_number_span(res.size) if res.size },
+                        {"label": "HTTP status", "text": res.http_status},
+                        {"label": _('Last check'), "datetime": res.last_check},
+                        {"label": "Resource hash", "text": res.resource_hash},
+                        {"label": "MIME type", "text": res.mime_type},
+                        {"label": "Category", "text": res.resource_category},
+                        {"label": "Validity start", "datetime": res.validity_start},
+                        {"label": "Validity end", "datetime": res.validity_end}]
             %}
         </div>
         {% endblock %}

--- a/ckanext/gla/templates/package/snippets/resource_form.html
+++ b/ckanext/gla/templates/package/snippets/resource_form.html
@@ -7,33 +7,30 @@
             label=_('HTTP status'),
             id='field-http_status',
             value=data.http_status,
-            error=errors.http_status,
-            classes=['control-medium']) }}
+            error=errors.http_status) }}
 
 {{ form.input('last_check',
                label=_('Last check'),
                type='date',
                value=data.last_check,
-               error=errors.last_check,)}}
+               error=errors.last_check) }}
 
 {{ form.input('resource_hash',
                 label=_('Resource hash'),
                 value=data.resource_hash,
-                error=errors.resource_hash,)}}
+                error=errors.resource_hash) }}
 
 {{ form.input('mime_type',
                 label=_('MIME type'),
                 id='field-mime_type',
                 value=data.mime_type,
-                error=errors.mime_type,
-                classes=['control-medium']) }}
+                error=errors.mime_type) }}
 
 {{ form.input('resource_category',
                 label=_('Category'),
                 id='field-resource_category',
                 value=data.resource_category,
-                error=errors.resource_category,
-                classes=['control-medium']) }}
+                error=errors.resource_category) }}
 
 {{ form.input('validity_start',
                 label=_('Validity start'),

--- a/ckanext/gla/templates/package/snippets/resource_form.html
+++ b/ckanext/gla/templates/package/snippets/resource_form.html
@@ -1,0 +1,49 @@
+{% ckan_extends %}
+
+{% block basic_fields_url %}
+{{ super() }}
+
+{{ form.input('http_status',
+            label=_('HTTP status'),
+            id='field-http_status',
+            value=data.http_status,
+            error=errors.http_status,
+            classes=['control-medium']) }}
+
+{{ form.input('last_check',
+               label=_('Last check'),
+               type='date',
+               value=data.last_check,
+               error=errors.last_check,)}}
+
+{{ form.input('resource_hash',
+                label=_('Resource hash'),
+                value=data.resource_hash,
+                error=errors.resource_hash,)}}
+
+{{ form.input('mime_type',
+                label=_('MIME type'),
+                id='field-mime_type',
+                value=data.mime_type,
+                error=errors.mime_type,
+                classes=['control-medium']) }}
+
+{{ form.input('resource_category',
+                label=_('Category'),
+                id='field-resource_category',
+                value=data.resource_category,
+                error=errors.resource_category,
+                classes=['control-medium']) }}
+
+{{ form.input('validity_start',
+                label=_('Validity start'),
+                type='date',
+                value=data.validity_start,
+                error=errors.validity_start,)}}
+
+{{ form.input('validity_end',
+                label=_('Validity end'),
+                type='date',
+                value=data.validity_end,
+                error=errors.validity_end,)}}
+{% endblock %}


### PR DESCRIPTION
Adds some fields to the resource schema, as specified in the ticket. None of the fields are mandatory but can be added by a user with edit access, either in the website or via API. They are displayed in the 'additional information' table on the resource detail pages but do not affect the parent dataset in any way.