### PR TITLE
DAT-517: Set the default dataset visibility to public

### DIFF
--- a/ckanext/gla/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/gla/templates/package/snippets/package_basic_fields.html
@@ -43,9 +43,8 @@
     <label for="field-private" class="form-label">{{ _('Visibility') }}</label>
     <div class="controls">
       <select id="field-private" name="private" class="form-control">
-        {% for option in [('True', _('Private')), ('False', _('Public'))] %}
-        <option value="{{ option[0] }}" {% if option[0] != data.private|trim %}selected="selected" {% endif %}>
-          {{ option[1] }}</option>
+        {% for option in [('False', _('Public')), ('True', _('Private'))] %}
+        <option value="{{ option[0] }}" {% if option[0] == data.private|trim %}selected="selected" {% endif %}>{{option[1]}}</option>
         {% endfor %}
       </select>
     </div>

--- a/ckanext/gla/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/gla/templates/package/snippets/package_basic_fields.html
@@ -38,7 +38,19 @@
 }}
 {% endblock %}
 
-
+{% block package_metadata_fields_visibility %}
+  <div class="form-group control-medium">
+    <label for="field-private" class="form-label">{{ _('Visibility') }}</label>
+    <div class="controls">
+      <select id="field-private" name="private" class="form-control">
+        {% for option in [('True', _('Private')), ('False', _('Public'))] %}
+        <option value="{{ option[0] }}" {% if option[0] != data.private|trim %}selected="selected" {% endif %}>
+          {{ option[1] }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
+  {% endblock %}
 
 {% block package_basic_fields_custom %}
 {{


### PR DESCRIPTION
This PR addresses [DAT-517](https://london.atlassian.net/browse/DAT-517).
The template code I've added is almost an exact copy of the `package_metadata_fields_visibility` block in the [package_basic_fields template](https://github.com/ckan/ckan/blob/master/ckan/templates/package/snippets/package_basic_fields.html#L92), but with the `==` replaced with `!=` so that the default selected value is `Public`.