### PR TITLE
Fix NotAuthorized error when team admin adds existing user to org

### DIFF
--- a/ckanext/gla/auth.py
+++ b/ckanext/gla/auth.py
@@ -5,17 +5,20 @@ def _requester_is_sysadmin(context):
     requester = context.get('user', None)
     return authz.is_sysadmin(requester)
 
+def _requester_is_manager(context):
+    requester = context.get('user', None)
+    return authz.has_user_permission_for_some_org(requester,'manage_group')
 
 def user_list(context, data_dict=None):
     """Only sysadmins should be allowed to view the full list of users"""
-    return {'success': _requester_is_sysadmin(context)}
+    return {'success': _requester_is_sysadmin(context) or _requester_is_manager(context)}
 
 
 def user_show(context, data_dict=None):
     """sysadmins can view all user profiles.
     If not a sysadmin, a user can only view their own profile.
     Based on: https://github.com/qld-gov-au/ckanext-qgov/blob/master/ckanext/qgov/common/auth_functions.py#L126"""
-    if _requester_is_sysadmin(context):
+    if _requester_is_sysadmin(context) or _requester_is_manager(context):
         return {'success': True}
     requester = context.get('user')
     id = data_dict.get('id', None)


### PR DESCRIPTION
Fixes [DAT-678](https://london.atlassian.net/browse/DAT-678) enabling [DAT-663](https://london.atlassian.net/browse/DAT-663).

Prior to this commit this was happening on the ajax'd autocomplete control resulting in the exception:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/flask/app.py", line 2076, in wsgi_app
	response = self.handle_exception(e)
  File "/usr/lib/python3.10/site-packages/flask/app.py", line 2073, in wsgi_app
	response = self.full_dispatch_request()
  File "/usr/lib/python3.10/site-packages/flask/app.py", line 1518, in full_dispatch_request
	rv = self.handle_user_exception(e)
  File "/usr/lib/python3.10/site-packages/flask/app.py", line 1516, in full_dispatch_request
	rv = self.dispatch_request()
  File "/usr/lib/python3.10/site-packages/flask_debugtoolbar/__init__.py", line 142, in dispatch_request
	return view_func(**req.view_args)
  File "/srv/app/src/ckan/ckan/views/api.py", line 442, in user_autocomplete
	user_list = get_action(u'user_autocomplete')(context, data_dict)
  File "/srv/app/src/ckan/ckan/logic/__init__.py", line 551, in wrapped
	result = _action(context, data_dict, **kw)
  File "/srv/app/src/ckan/ckan/logic/__init__.py", line 652, in wrapper
	return action(context, data_dict)
  File "/srv/app/src/ckan/ckan/logic/action/get.py", line 1640, in user_autocomplete
	_check_access('user_autocomplete', context, data_dict)
  File "/srv/app/src/ckan/ckan/logic/__init__.py", line 362, in check_access
	raise NotAuthorized(msg)
ckan.logic.NotAuthorized
```

This would previously work for a sysadmin but not a team admin (organization admin).

Fix extends the authorization check from sysadmins to users with any 'manage_group' permissions.

The `auth.user_list` function is scoped in `ckanext/gla/plugin.py` to the `user_show` action so should not inadvertently affect other actions.