### PR TITLE
Work around exception when viewing /pages and /pages_edit

### DIFF
--- a/ckanext/gla/templates/page.html
+++ b/ckanext/gla/templates/page.html
@@ -2,6 +2,8 @@
 
 {%- block page -%}
 
+  {% block toolbar %}{% endblock %}
+
   {% block skip %}
     <div class="visually-hidden-focusable"><a href="#content">{{ _('Skip to main content') }}</a></div>
   {% endblock %}


### PR DESCRIPTION
Fix DAT-693 visiting /pages_edit raises a 500 error

Specific bug: https://london.atlassian.net/browse/DAT-693

Unlocks story: https://london.atlassian.net/browse/DAT-674

Child pages of page.html expect a toolbar block to be declared.

The fix adds the block.