### PR TITLE
Workaround / Patch for Null pointer exception when visiting /group or /organization

### DIFF
--- a/ckanext/gla/templates/snippets/search_form.html
+++ b/ckanext/gla/templates/snippets/search_form.html
@@ -24,7 +24,7 @@
         <label style="pointer-events:none;" id="order-by-label">{{ _('Order by') }}</label>
               {% for label, value in sorting %}
                 {% if label and value %}
-                    {% set is_selected = sorting_selected.split(",")[0] == value %}
+                    {% set is_selected = sorting_selected.split(",")[0] == value if sorting_selected else false %}
                     {% if loop.index != 1 %} |{% endif %}
                     <a href={{ h.remove_url_param("sort", replace=value)}}
                         class="
@@ -56,7 +56,7 @@
       <span>{{ form.hidden_from_list(fields=fields) }}</span>
     {%- endif %}
   {% endblock %}
-  
+
   {% block search_facets %}
     {% if facets %}
       <p class="filter-list">


### PR DESCRIPTION
Fixes [DAT-692](https://london.atlassian.net/browse/DAT-692), visiting `/organization`, `/group` or an individual `/organization/page` raises a 500 error, rather than displaying the appropriate page.

Prior to this patch this would essentially happen on any page including this search form partial.

The most parsimonious fix seems to be to work around the problem in the view template, as the view is triggered from CKAN.  Anything else would likely require overriding much bigger pieces of CKAN, increasing the size and scope of change.