### PR TITLE
Add link to harvester JSON configuration documentation

### DIFF
--- a/ckanext/gla/templates/source/new_source_form.html
+++ b/ckanext/gla/templates/source/new_source_form.html
@@ -54,9 +54,11 @@ the changes rather than using ckan_extends.
 
   {{ form.select('frequency', id='field-frequency', label=_('Update frequency'), options=h.harvest_frequencies(), selected=data.frequency, error=errors.frequency) }}
 
-  {% block extra_config %}
-  {{ form.textarea('config', id='field-config', label=_('Configuration'), value=data.config, error=errors.config) }}
-  {% endblock extra_config %}
+  {% call form.textarea('config', id='field-config', label=_('JSON Configuration'), value=data.config, error=errors.config, placeholder='{}') %}
+  <span class="info-block">
+    Need help configuring a harvester?  See the <a href="https://github.com/GreaterLondonAuthority/dfl-ckanext-havester/blob/1.x/docs/harvester_config.md#harvester-configuration">Harvester configuration documentation</a>.
+  </span>
+{% endcall %}
 
   {# if we have a default group then this wants remembering #}
   {% if data.group_id %}


### PR DESCRIPTION
Part of DAT-687 story AC-1.

https://london.atlassian.net/browse/DAT-687?focusedCommentId=188640

## Before change screenshot

<img width="700" alt="Screenshot 2024-06-28 at 15 34 27" src="https://github.com/GreaterLondonAuthority/dfl-ckanext/assets/17060/e5b9d953-8146-4ab1-b4ac-12c84c3460e2">

## After change screenshot

<img width="711" alt="Screenshot 2024-06-28 at 15 33 38" src="https://github.com/GreaterLondonAuthority/dfl-ckanext/assets/17060/b5589de4-fa5a-4bfb-8d60-9da647d53370">

The documentation link points to the location of [this document](https://github.com/GreaterLondonAuthority/dfl-ckanext-havester/blob/harvest-private-datapress-datasets/docs/harvester_config.md#harvester-configuration) [after this PR](https://github.com/GreaterLondonAuthority/dfl-ckanext-havester/pulls) is merged (i.e. we will point to the document on the default `1.x` branch of that repository).
