### PR TITLE
Better Boosting and ckan defaults

### DIFF
--- a/ckanext/gla/search.py
+++ b/ckanext/gla/search.py
@@ -38,6 +38,17 @@ def add_quality_to_search(search_params):
             # https://nolanlawson.com/2012/06/02/comparing-boost-methods-in-solr/
             # 
             "bf": f"copy_data_quality^{data_quality_boost_factor} copy_dataset_boost^{dataset_boost_boost_factor}"
+            # NOTE
+            #
+            # The query field settings shown below are the CKAN
+            # defaults. If in the future it becomes desirable to tweak
+            # the importance of these fields for relevance, this line
+            # can be uncommented and the values can be changed.
+            #
+            # Note also that the text field contains a large amount of
+            # metadata copied from other fields in a stemmed form.
+
+            # "qf":"name^4 title^4 tags^2 groups^2 text"
             }
 
 @toolkit.side_effect_free

--- a/ckanext/gla/search.py
+++ b/ckanext/gla/search.py
@@ -20,14 +20,7 @@ def _empty_or_none(string):
     return string == "" or string is None
 
 def add_quality_to_search(search_params):
-    search_terms = search_params.get("q")
-    if _empty_or_none(search_terms) or search_terms == "*:*":
-        q = "*:*"
-    else:
-        q = f"text:{search_terms}"
-    
     return {**search_params,
-            "q": q,
             # NOTE the bf parameter adds these additional boosts into
             # the query/results. There are two numeric fields stored
             # in our dataset records which admins can adjust to

--- a/ckanext/gla/search.py
+++ b/ckanext/gla/search.py
@@ -25,10 +25,27 @@ def add_quality_to_search(search_params):
         q = "*:*"
     else:
         q = f"text:{search_terms}"
-    query = f"{q} _val_:copy_data_quality^{data_quality_boost_factor} _val_:copy_dataset_boost^{dataset_boost_boost_factor}"
-
+    
     return {**search_params,
-            "q": query}
+            "q": q,
+            # NOTE the bf parameter adds these additional boosts into
+            # the query/results. There are two numeric fields stored
+            # in our dataset records which admins can adjust to
+            # influence a datasets ranking
+            #
+            # These fields are weighted by the appropriate boost
+            # factors, and the computed boost is added via addition to
+            # the relevance score. It may be better in the future to
+            # move this to a multiplicative boosting approach, as the
+            # boosts will then become a function of text-match
+            # relevance, rather than being universally applied.
+            #
+            # A good article on the subject is here:
+            #
+            # https://nolanlawson.com/2012/06/02/comparing-boost-methods-in-solr/
+            # 
+            "bf": f"copy_data_quality^{data_quality_boost_factor} copy_dataset_boost^{dataset_boost_boost_factor}"
+            }
 
 @toolkit.side_effect_free
 def debug(context, data_dict={}):


### PR DESCRIPTION
This implements [DAT-728](https://london.atlassian.net/browse/DAT-728) returning to largely default CKAN search behaviour.

NOTE: the commits in this PR are layered such that a refactoring of the existing boost functionality occurs first, with no behaviour change.  This refactoring means we can combine the existing method of boosting via the fields dataset quality and dataset boost fields with the CKAN default field level boosts in the following commit.

It completes [DAT-703](https://london.atlassian.net/browse/DAT-703) by clarifying query behaviour and avoiding potential issues with undefined query behaviour due to string concatenation.

It also enables CKAN advanced search functionality which should also resolve [DAT-699](
https://london.atlassian.net/browse/DAT-699) though with a different syntax for boolean search operators:

- `AND` is `&&`
- `OR` is `||`

If we want to use `AND` and `OR` here, then a future PR may want to look at using the edismax query parser instead of the dismax parser.

We also lift the default CKAN field level boosts into our extension to colocate the query boosting functionality and make further configuration of boosting easier, which resolves [DAT-695](https://london.atlassian.net/browse/DAT-695).

