### PR TITLE
Alphabetical sorting of dataset search results

### DIFF
--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -22,7 +22,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         toolkit.add_template_directory(config_, "templates")
         toolkit.add_public_directory(config_, "public")
         toolkit.add_resource("assets", "gla")
-        custom_fields.add_copy_fields()
+        custom_fields.add_solr_config()
 
     # IAuthFunctions
     def get_auth_functions(self):

--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -514,6 +514,10 @@ input.search.form-control+.input-group-btn .btn {
     border-radius: 0 6px 6px 0;
 }
 
+.search-form .search-input-group {
+    margin-bottom: 0.25rem;
+}
+
 /* Forms */
 
 .form-control {

--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -518,6 +518,10 @@ input.search.form-control+.input-group-btn .btn {
     margin-bottom: 0.25rem;
 }
 
+.dfl-hint {
+    margin-bottom: 0.5rem;
+}
+
 /* Forms */
 
 .form-control {

--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -518,6 +518,10 @@ input.search.form-control+.input-group-btn .btn {
     margin-bottom: 0.25rem;
 }
 
+.dfl-result-count {
+    margin-bottom: 0.5rem;
+}
+
 .dfl-hint {
     margin-bottom: 0.5rem;
 }

--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -1313,7 +1313,6 @@ p.accordion__empty.empty {
 }
 
 .search-header__order {
-    float: right;
     margin-bottom: 15px;
 }
 .search-header__order a {

--- a/ckanext/gla/templates/snippets/search_form.html
+++ b/ckanext/gla/templates/snippets/search_form.html
@@ -18,6 +18,19 @@
         {% endblock %}
         </div>
     </div>
+
+{% block search_input %}
+<div class="input-group search-input-group">
+    <input aria-label="{% block header_site_search_label %}{{ placeholder }}{% endblock %}" id="field-giant-search" type="text" class="form-control input-lg" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
+    {% block search_input_button %}
+    <span class="input-group-btn">
+    <button class="btn btn-default btn-lg" type="submit" value="search" aria-label="{{_('Submit')}}">
+        <i class="fa fa-search"></i>
+    </button>
+    </span>
+    {% endblock %}
+</div>
+{% endblock %}
     <div class="search-header__order">
         {% block search_sortby %}
         {% if sorting %}
@@ -38,18 +51,6 @@
       {% endblock %}
     </div>
 
-{% block search_input %}
-<div class="input-group search-input-group">
-    <input aria-label="{% block header_site_search_label %}{{ placeholder }}{% endblock %}" id="field-giant-search" type="text" class="form-control input-lg" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
-    {% block search_input_button %}
-    <span class="input-group-btn">
-    <button class="btn btn-default btn-lg" type="submit" value="search" aria-label="{{_('Submit')}}">
-        <i class="fa fa-search"></i>
-    </button>
-    </span>
-    {% endblock %}
-</div>
-{% endblock %}
 
   {% block search_search_fields %}
     {% if fields -%}

--- a/ckanext/gla/templates/snippets/search_form.html
+++ b/ckanext/gla/templates/snippets/search_form.html
@@ -33,7 +33,7 @@
 {% endblock %}
     <div class="search-header__order">
         {% block search_sortby %}
-        {% if sorting %}
+        {% if sorting and type == 'dataset' %}
         <label style="pointer-events:none;" id="order-by-label">{{ _('Order by') }}</label>
               {% for label, value in sorting %}
                 {% if label and value %}

--- a/ckanext/gla/templates/snippets/search_form.html
+++ b/ckanext/gla/templates/snippets/search_form.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 
 {% set placeholder = 'Please enter a search term e.g. environment' if type == 'dataset' else 'Search {type}s...'.format(type=type) %}
-{% set sorting = [(_('Relevance'), 'score desc'), (_('Last Modified'), 'metadata_modified desc'), (_('Name (A-Z)'), 'title_string asc'), (_('Name (Z-A)'), 'title_string desc')] %}
+{% set sorting = [(_('Relevance'), 'score desc'), (_('Last Modified'), 'metadata_modified desc'), (_('Name (A-Z)'), 'dfl_title_sort asc'), (_('Name (Z-A)'), 'dfl_title_sort desc')] %}
 {% set search_class = search_class if search_class else 'search-giant' %}
 {% set no_bottom_border = no_bottom_border if no_bottom_border else false %}
 {% set form_id = form_id if form_id else false %}

--- a/ckanext/gla/templates/snippets/search_form.html
+++ b/ckanext/gla/templates/snippets/search_form.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 
 {% set placeholder = 'Please enter a search term e.g. environment' if type == 'dataset' else 'Search {type}s...'.format(type=type) %}
-{% set sorting = [(_('Relevance'), 'score desc'), (_('Last Modified'), 'metadata_modified desc')] %}
+{% set sorting = [(_('Relevance'), 'score desc'), (_('Last Modified'), 'metadata_modified desc'), (_('Name (A-Z)'), 'title_string asc'), (_('Name (Z-A)'), 'title_string desc')] %}
 {% set search_class = search_class if search_class else 'search-giant' %}
 {% set no_bottom_border = no_bottom_border if no_bottom_border else false %}
 {% set form_id = form_id if form_id else false %}

--- a/ckanext/gla/templates/snippets/search_result_text.html
+++ b/ckanext/gla/templates/snippets/search_result_text.html
@@ -1,45 +1,44 @@
 {#
 
     Displays a test for results of a search.
-    
+
     query          - The text that was searched for
     count          - The number of results for the search
     type           - Search result type (dataset, group, organization)
     title_override - Override the title
-    
+
     Example:
-    
+
     {% snippet 'snippets/search_result_text.html', query=query, count=count, type='dataset' %}
-    
+
     #}
     <h1>
         {% if type == 'dataset' %}
-        {% set text_query = ungettext('Search results for "{query}"', 'Search results for "{query}"', count) %}
+        {% set text_query = ungettext('Search result for "{query}"', 'Search results for "{query}"', count) %}
         {% set text_query_none = _('Search results for "{query}"') %}
         {% set text_no_query = ungettext('Search {number} dataset', 'Search {number} datasets', count) %}
         {% set text_no_query_none = _('No results found') %}
-    
+
     {% elif type == 'group' %}
-        {% set text_query = ungettext('"{query}"', '"{query}"', count) %}
-        {% set text_query_none = _('"{query}"') %}
-        {% set text_no_query = ungettext('{number} group found', '{number} groups found', count) %}
-        {% set text_no_query = _('Groups') %}
+        {% set text_query = ungettext('Group search result for "{query}"', 'Group search results for "{query}"', count) %}
+        {% set text_query_none = _('No groups found for "{query}"') %}
+        {% set text_no_query = ungettext('Search {number} group', 'Search {number} groups', count) %}
         {% set text_no_query_none = _('No groups found') %}
-    
+
     {% elif type == 'organization' %}
-        {% set text_query = ungettext('"{query}"', '"{query}"', count) %}
-        {% set text_query_none = _('"{query}"') %}
-        {% set text_no_query = _('Organisations') %}
+        {% set text_query = ungettext('Organisation search result for "{query}"', 'Organisation search results for "{query}"', count) %}
+        {% set text_query_none = _('No organisations found for "{query}"') %}
+        {% set text_no_query = ungettext('Search {number} organisation', 'Search {number} organisations', count) %}
         {% set text_no_query_none = _('No organisations found') %}
-    
+
     {% else %}
         {% set text_query_singular = '{number} ' + type + ' found for "{query}"' %}
         {% set text_query_plural = '{number} ' + type + 's found for "{query}"' %}
         {% set text_query_none_plural = 'No ' + type + 's found for "{query}"' %}
-        {% set text_no_query_singular = '{number} ' + type + ' found' %}        
+        {% set text_no_query_singular = '{number} ' + type + ' found' %}
         {% set text_no_query_plural = '{number} ' + type + 's found' %}
-        {% set text_no_query_none_plural = 'No ' + type + 's found' %}      
-    
+        {% set text_no_query_none_plural = 'No ' + type + 's found' %}
+
         {% set text_query = ungettext(text_query_singular, text_query_plural, count) %}
         {% set text_query_none = _(text_query_none_plural) %}
         {% set text_no_query = ungettext(text_no_query_singular, text_no_query_plural, count) %}
@@ -76,24 +75,24 @@
         {% set text_no_query_none = '' %}
 
     {% elif type == 'group' %}
-        {% set text_query = ungettext('{number} group', '{number} groups', count) %}
-        {% set text_query_none = _('No groups found') %}
-        {% set text_no_query = ungettext('{number} group', '{number} groups', count) %}
-        {% set text_no_query_none = _('No groups found') %}
+        {% set text_query = ungettext('Showing {number} group.', 'Showing {number} groups.', count) %}
+        {% set text_query_none = '' %}
+        {% set text_no_query = '' %}
+        {% set text_no_query_none = '' %}
 
     {% elif type == 'organization' %}
-        {% set text_query = ungettext('{number} organisation', '{number} organisations', count) %}
-        {% set text_query_none = _('No organisations found') %}
-        {% set text_no_query = ungettext('{number} organisation', '{number} organisations', count) %}
-        {% set text_no_query_none = _('No organisations found') %}
+        {% set text_query = ungettext('Showing {number} organisation.', 'Showing {number} organisations.', count) %}
+        {% set text_query_none = '' %}
+        {% set text_no_query = '' %}
+        {% set text_no_query_none = '' %}
 
     {% else %}
         {% set text_query_singular = '{number} ' + type + ' found for "{query}"' %}
         {% set text_query_plural = '{number} ' + type + 's found for "{query}"' %}
         {% set text_query_none_plural = 'No ' + type + 's found for "{query}"' %}
-        {% set text_no_query_singular = '{number} ' + type + ' found' %}        
+        {% set text_no_query_singular = '{number} ' + type + ' found' %}
         {% set text_no_query_plural = '{number} ' + type + 's found' %}
-        {% set text_no_query_none_plural = 'No ' + type + 's found' %}      
+        {% set text_no_query_none_plural = 'No ' + type + 's found' %}
 
         {% set text_query = ungettext(text_query_singular, text_query_plural, count) %}
         {% set text_query_none = _(text_query_none_plural) %}

--- a/ckanext/gla/templates/snippets/search_result_text.html
+++ b/ckanext/gla/templates/snippets/search_result_text.html
@@ -16,7 +16,7 @@
         {% if type == 'dataset' %}
         {% set text_query = ungettext('Search results for "{query}"', 'Search results for "{query}"', count) %}
         {% set text_query_none = _('Search results for "{query}"') %}
-        {% set text_no_query = _('Search') %}
+        {% set text_no_query = ungettext('Search {number} dataset', 'Search {number} datasets', count) %}
         {% set text_no_query_none = _('No results found') %}
     
     {% elif type == 'group' %}
@@ -64,18 +64,16 @@
         {%- endif -%}
     {% endif %}
     </h1>
-    
-    <span>
 
     <div class='lead dfl-hint'>
       Use London’s data to help you understand the city and develop solutions.
     </div>
 
     {% if type == 'dataset' %}
-        {% set text_query = ungettext('{number} result', '{number} results', count) %}
-        {% set text_query_none = _('No results found') %}
-        {% set text_no_query = ungettext('{number} result', '{number} results', count) %}
-        {% set text_no_query_none = _('No results found') %}
+        {% set text_query = ungettext('Showing {number} result.', 'Showing {number} results.', count) %}
+        {% set text_query_none = '' %}
+        {% set text_no_query = '' %}
+        {% set text_no_query_none = '' %}
 
     {% elif type == 'group' %}
         {% set text_query = ungettext('{number} group', '{number} groups', count) %}
@@ -105,15 +103,16 @@
 
     {% if query %}
         {%- if count -%}
-        {{ text_query.format(number=h.localised_number(count), query=query, type=type) }}
+          <div class='dfl-result-count'>
+            {{ text_query.format(number=h.localised_number(count), query=query, type=type) }}
+          </div>
         {%- else -%}
         {{ text_query_none.format(query=query, type=type) }}
         {%- endif -%}
     {%- else -%}
         {%- if count -%}
-        {{ text_no_query.format(number=h.localised_number(count), type=type) }}
+          {{ text_no_query.format(number=h.localised_number(count), type=type) }}
         {%- else -%}
         {{ text_no_query_none.format(type=type) }}
         {%- endif -%}
     {%- endif -%}
-    </span>

--- a/ckanext/gla/templates/snippets/search_result_text.html
+++ b/ckanext/gla/templates/snippets/search_result_text.html
@@ -66,6 +66,11 @@
     </h1>
     
     <span>
+
+    <div class='lead dfl-hint'>
+      Use London’s data to help you understand the city and develop solutions.
+    </div>
+
     {% if type == 'dataset' %}
         {% set text_query = ungettext('{number} result', '{number} results', count) %}
         {% set text_query_none = _('No results found') %}


### PR DESCRIPTION
Implements [DAT-711](https://london.atlassian.net/browse/DAT-711) adding alphabetical sorting of dataset search results and fixes a bug we discovered in the process ([DAT-737](https://london.atlassian.net/browse/DAT-737)) when sorting organisation and group pages.

NOTE: The [first commit](https://github.com/GreaterLondonAuthority/dfl-ckanext/pull/94/commits/cd279eaeeecb59a7f28e7a700c181e9e886c1567) of this PR implements just the addition of the new sorting components, and the remaining commits align the design towards the new design wireframe.  

The [final commit](https://github.com/GreaterLondonAuthority/dfl-ckanext/pull/94/commits/ca1b9e773404589c650bbe6800a365e4195d09c2) in this PR changes the field used for sorting to a new special field we added specifically for the purpose of title sorting; without this change sorting was found to be case sensitive and not handle datasets whose names begin with non alphanumeric characters very well.  More details can be found in the commit message.

### Before Screenshot

<img width="1321" alt="Screenshot 2024-07-08 at 11 41 08" src="https://github.com/GreaterLondonAuthority/dfl-ckanext/assets/17060/4072bcee-5f90-47c6-a1b9-0c0a9b06b3c9">

### After Screenshots

<img width="1309" alt="Screenshot 2024-07-08 at 11 40 26" src="https://github.com/GreaterLondonAuthority/dfl-ckanext/assets/17060/71b9de21-bc8c-4839-848b-2b12dad4dd1d">

