### PR TITLE
DAT-696: Override package search methods to add highlighting

### DIFF
--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -1,9 +1,14 @@
-from ckan.types import Schema
+from collections import OrderedDict
+from typing import Any
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
+from ckan.lib.helpers import markdown_extract
+from ckan.types import Schema
+from markupsafe import Markup
 
-from . import auth, helpers, views, search, timestamps, custom_fields
-from collections import OrderedDict
+from . import auth, custom_fields, helpers, search, timestamps, views
+from .search_highlight import action, query
 
 
 class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
@@ -33,14 +38,84 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     def before_dataset_search(self, search_params):
         # Include showcases *and* datasets in the search results:
         # We only want Showcases to show up when there is a search query
-        if search_params.get("q", "") != "":
-            fq = search_params.get("fq", "")
-            search_params.update(
-                {"fq": fq + " dataset_type:dataset || dataset_type:showcase"}
+        search_params.update(
+            {
+                "hl": "on",
+                "hl.fl": "title,notes,search_description,organization",
+                "hl.fragsize": 200,
+                "hl.simple.pre": "[[",
+                "hl.simple.post": "]]",
+            }
+        )
+        return search_params
+
+
+    # IPackageController
+    def after_dataset_search(
+        self, search_results: dict[str, Any], search_params: dict[str, Any]
+    ):
+
+        def _get_highlighted_field(
+            field_name_in_highlight_dict: str, index_id: str
+        ) -> str | None:
+            highlighted_field = search_results["highlighting"][index_id].get(
+                field_name_in_highlight_dict, None
             )
 
-        # Then add the quality parts to the search query:
-        return search.add_quality_to_search(search_params)
+            if highlighted_field and isinstance(highlighted_field, list):
+                return highlighted_field[0]
+
+            return highlighted_field
+
+        for result in search_results["results"]:
+            index_id = result.get("index_id", False)
+
+            if index_id and index_id in search_results["highlighting"]:
+                highlighted_title = _get_highlighted_field("title", index_id)
+                highlighted_notes = _get_highlighted_field("notes", index_id)
+                highlighted_search_description = _get_highlighted_field(
+                    "extras_search_description", index_id
+                )
+                highlighted_organization_title = _get_highlighted_field(
+                    "organization", index_id
+                )
+
+                title = highlighted_title or result["title"]
+                notes = highlighted_notes or result.get("notes")
+                search_description = highlighted_search_description or result.get(
+                    "search_description"
+                )
+                organization = highlighted_organization_title or result["organization"]["title"]
+
+                # Fall back to notes if search_description is present but not highlighted
+                if search_description and "[[" in search_description:
+                    search_description = search_description
+                else:
+                    search_description = notes
+
+                result["title"] = title.replace(
+                    "[[", '<span class="dataset-search-highlight">'
+                ).replace("]]", "</span>")
+
+                result["organization"]["title"] = organization.replace(
+                    "[[", '<span class="dataset-search-highlight">'
+                ).replace("]]", "</span>")
+
+                # Handle unclosed tags that flow into the next search result
+                sanitized_search_description = str(markdown_extract(search_description, extract_length=240))
+                sanitized_search_description_list = []
+                for substring in sanitized_search_description.split("[["):
+                    if not substring:
+                        continue
+                    if "]]" in substring:
+                        span_content, rest = substring.split("]]")
+                        sanitized_search_description_list.append(Markup(f'<span class="dataset-search-highlight">{span_content}</span>'))
+                        sanitized_search_description_list.append(markdown_extract(rest, extract_length=0))
+                    else:
+                        sanitized_search_description_list.append(markdown_extract(substring, extract_length=0))
+                result["search_description"] = sanitized_search_description_list
+
+        return search_results
 
     def after_dataset_create(self, ctx, package):
         timestamps.override(ctx, package)
@@ -61,8 +136,11 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
     # IActions
     def get_actions(self):
-        return {"debug_dataset_search": search.debug,
-                "log_chosen_search_result": search.log_selected_result}
+        return {
+            "debug_dataset_search": search.debug,
+            "log_chosen_search_result": search.log_selected_result,
+            "package_search": action.package_search,
+        }
 
     # IDatasetForm
     # Follows https://docs.ckan.org/en/2.10/extensions/adding-custom-fields.html
@@ -78,20 +156,23 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
     def show_package_schema(self) -> Schema:
         schema = super(GlaPlugin, self).show_package_schema()
-        schema.update({
-            field: [
-                toolkit.get_converter("convert_from_extras"),
-                toolkit.get_validator("ignore_missing"),
-            ]
-            for field in custom_fields.custom_dataset_fields.keys()})
-        schema.update({
-            "harvest_source_title":
-            [
-                toolkit.get_converter("convert_from_extras"),
-                toolkit.get_validator("ignore_missing"),
-            ]
-
-        })
+        schema.update(
+            {
+                field: [
+                    toolkit.get_converter("convert_from_extras"),
+                    toolkit.get_validator("ignore_missing"),
+                ]
+                for field in custom_fields.custom_dataset_fields.keys()
+            }
+        )
+        schema.update(
+            {
+                "harvest_source_title": [
+                    toolkit.get_converter("convert_from_extras"),
+                    toolkit.get_validator("ignore_missing"),
+                ]
+            }
+        )
         return schema
 
     def is_fallback(self):
@@ -102,15 +183,19 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
     # IFacets
     def dataset_facets(self, facets_dict, _):
-        return OrderedDict([("res_format", facets_dict["res_format"]),
-                               ("organization", facets_dict["organization"]),
-                               ("project_name", toolkit._("Projects")),
-                               # Entry type is disabled for now as the value is null for harvested datasets
-                               # The filter works, so enabling it will allow us to filter for datasets with
-                               # the field set, either by manual edit, script, or updates to harvester
-                               # ("entry_type", toolkit._("Type")),
-                               ("harvest_source_title", toolkit._("Sources")),
-                               ("license_id", facets_dict["license_id"])])
+        return OrderedDict(
+            [
+                ("res_format", facets_dict["res_format"]),
+                ("organization", facets_dict["organization"]),
+                ("project_name", toolkit._("Projects")),
+                # Entry type is disabled for now as the value is null for harvested datasets
+                # The filter works, so enabling it will allow us to filter for datasets with
+                # the field set, either by manual edit, script, or updates to harvester
+                # ("entry_type", toolkit._("Type")),
+                ("harvest_source_title", toolkit._("Sources")),
+                ("license_id", facets_dict["license_id"]),
+            ]
+        )
 
     def organization_facets(self, facets_dict, *args):
         return facets_dict

--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -1374,6 +1374,12 @@ li.dataset-item {
     display: block;
 }
 
+.dataset-search-highlight {
+    border-radius: 1px;
+    background: #ffff73;
+    box-shadow: 0 0 0 3px #ffff73;
+}
+
 .dataset-notes {
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;

--- a/ckanext/gla/search_highlight/action.py
+++ b/ckanext/gla/search_highlight/action.py
@@ -1,0 +1,204 @@
+import json
+import logging
+from typing import Any, cast
+
+import ckan
+import ckan.authz as authz
+import ckan.lib.plugins as lib_plugins
+import ckan.plugins as plugins
+from ckan.common import asbool, config
+from ckan.lib import search
+from ckan.logic.action.get import ValidationError, _check_access, _validate
+from ckan.types import ActionResult, Context, DataDict
+
+log = logging.getLogger(__name__)
+
+
+def package_search(context: Context, data_dict: DataDict) -> ActionResult.PackageSearch:
+    """
+    This is a copy of the original package_search function from ckan.logic.action.get
+    with the following changes:
+    - Add highlighting to return value
+
+    Please update with upstream method when upgrading CKAN.
+    TODO: Submit a PR to upstream CKAN to allow for this to be done in a cleaner way.
+    """
+    # sometimes context['schema'] is None
+    schema = context.get("schema") or ckan.logic.schema.default_package_search_schema()
+    data_dict, errors = _validate(data_dict, schema, context)
+    # put the extras back into the data_dict so that the search can
+    # report needless parameters
+    data_dict.update(data_dict.get("__extras", {}))
+    data_dict.pop("__extras", None)
+    if errors:
+        raise ValidationError(errors)
+
+    model = context["model"]
+    session = context["session"]
+    user = context.get("user")
+
+    _check_access("package_search", context, data_dict)
+
+    # Move ext_ params to extras and remove them from the root of the search
+    # params, so they don't cause and error
+    data_dict["extras"] = data_dict.get("extras", {})
+    for key in [key for key in data_dict.keys() if key.startswith("ext_")]:
+        data_dict["extras"][key] = data_dict.pop(key)
+
+    # set default search field
+    data_dict["df"] = "text"
+
+    # check if some extension needs to modify the search params
+    for item in plugins.PluginImplementations(plugins.IPackageController):
+        data_dict = item.before_dataset_search(data_dict)
+
+    # the extension may have decided that it is not necessary to perform
+    # the query
+    abort = data_dict.get("abort_search", False)
+
+    if data_dict.get("sort") in (None, "rank"):
+        data_dict["sort"] = config.get("ckan.search.default_package_sort")
+
+    results: list[dict[str, Any]] = []
+    facets: dict[str, Any] = {}
+    count = 0
+
+    if not abort:
+        if asbool(data_dict.get("use_default_schema")):
+            data_source = "data_dict"
+        else:
+            data_source = "validated_data_dict"
+        data_dict.pop("use_default_schema", None)
+
+        result_fl = data_dict.get("fl")
+        if not result_fl:
+            data_dict["fl"] = "id {0}".format(data_source)
+        else:
+            data_dict["fl"] = " ".join(result_fl)
+
+        data_dict.setdefault("fq", "")
+
+        # Remove before these hit solr FIXME: whitelist instead
+        include_private = asbool(data_dict.pop("include_private", False))
+        include_drafts = asbool(data_dict.pop("include_drafts", False))
+        include_deleted = asbool(data_dict.pop("include_deleted", False))
+
+        if not include_private:
+            data_dict["fq"] = "+capacity:public " + data_dict["fq"]
+
+        if "+state" not in data_dict["fq"]:
+            states = ["active"]
+            if include_drafts:
+                states.append("draft")
+            if include_deleted:
+                states.append("deleted")
+            data_dict["fq"] += " +state:({})".format(" OR ".join(states))
+
+        # Pop these ones as Solr does not need them
+        extras = data_dict.pop("extras", None)
+
+        # enforce permission filter based on user
+        if context.get("ignore_auth") or (user and authz.is_sysadmin(user)):
+            labels = None
+        else:
+            labels = lib_plugins.get_permission_labels().get_user_dataset_labels(
+                context["auth_user_obj"]
+            )
+
+        query = search.query_for(model.Package)
+        query.run(data_dict, permission_labels=labels)
+
+        # Add them back so extensions can use them on after_search
+        data_dict["extras"] = extras
+
+        if result_fl:
+            for package in query.results:
+                if isinstance(package, str):
+                    package = {result_fl[0]: package}
+                extras = cast("dict[str, Any]", package.pop("extras", {}))
+                package.update(extras)
+                results.append(package)
+        else:
+            for package in query.results:
+                # get the package object
+                package_dict = package.get(data_source)
+                ## use data in search index if there
+                if package_dict:
+                    # the package_dict still needs translating when being viewed
+                    package_dict = json.loads(package_dict)
+                    if context.get("for_view"):
+                        for item in plugins.PluginImplementations(
+                            plugins.IPackageController
+                        ):
+                            package_dict = item.before_dataset_view(package_dict)
+                    results.append(package_dict)
+                else:
+                    log.error(
+                        "No package_dict is coming from solr for package " "id %s",
+                        package["id"],
+                    )
+
+        count = query.count
+        facets = query.facets
+
+    search_results: dict[str, Any] = {
+        "count": count,
+        "facets": facets,
+        "results": results,
+        "sort": data_dict["sort"],
+    }
+
+    # create a lookup table of group name to title for all the groups and
+    # organizations in the current search's facets.
+    group_names = []
+    for field_name in ("groups", "organization"):
+        group_names.extend(facets.get(field_name, {}).keys())
+
+    groups = (
+        session.query(model.Group.name, model.Group.title)
+        # type_ignore_reason: incomplete SQLAlchemy types
+        .filter(model.Group.name.in_(group_names)).all()  # type: ignore
+        if group_names
+        else []
+    )
+    group_titles_by_name = dict(groups)
+
+    # Transform facets into a more useful data structure.
+    restructured_facets: dict[str, Any] = {}
+    for key, value in facets.items():
+        restructured_facets[key] = {"title": key, "items": []}
+        for key_, value_ in value.items():
+            new_facet_dict = {}
+            new_facet_dict["name"] = key_
+            if key in ("groups", "organization"):
+                display_name = group_titles_by_name.get(key_, key_)
+                display_name = (
+                    display_name if display_name and display_name.strip() else key_
+                )
+                new_facet_dict["display_name"] = display_name
+            elif key == "license_id":
+                license = model.Package.get_license_register().get(key_)
+                if license:
+                    new_facet_dict["display_name"] = license.title
+                else:
+                    new_facet_dict["display_name"] = key_
+            else:
+                new_facet_dict["display_name"] = key_
+            new_facet_dict["count"] = value_
+            restructured_facets[key]["items"].append(new_facet_dict)
+    search_results["search_facets"] = restructured_facets
+
+    # check if some extension needs to modify the search results
+    for item in plugins.PluginImplementations(plugins.IPackageController):
+        search_results = item.after_dataset_search(search_results, data_dict)
+
+    # After extensions have had a chance to modify the facets, sort them by
+    # display name.
+    for facet in search_results["search_facets"]:
+        search_results["search_facets"][facet]["items"] = sorted(
+            search_results["search_facets"][facet]["items"],
+            key=lambda facet: facet["display_name"],
+            reverse=True,
+        )
+
+    return search_results

--- a/ckanext/gla/search_highlight/query.py
+++ b/ckanext/gla/search_highlight/query.py
@@ -12,6 +12,10 @@ from werkzeug.datastructures import MultiDict
 
 log = logging.getLogger(__name__)
 
+VALID_SOLR_PARAMETERS.update(
+    ["hl", "hl.fl", "hl.fragsize", "hl.simple.pre", "hl.simple.post"]
+)
+
 
 class PatchedPackageSearchQuery(PackageSearchQuery):
     def run(
@@ -151,4 +155,10 @@ class PatchedPackageSearchQuery(PackageSearchQuery):
         for field, values in self.facets.items():
             self.facets[field] = dict(zip(values[0::2], values[1::2]))
 
+        # Get Solr highlighting
+        self.highlighting = solr_response.highlighting
+
         return {"results": self.results, "count": self.count}
+
+
+_QUERIES["package"] = PatchedPackageSearchQuery

--- a/ckanext/gla/search_highlight/query.py
+++ b/ckanext/gla/search_highlight/query.py
@@ -1,0 +1,154 @@
+import logging
+from typing import Any, Optional, cast
+
+import pysolr
+from ckan.common import asbool, config
+from ckan.lib.search import _QUERIES
+from ckan.lib.search.common import (SearchError, SearchQueryError,
+                                    make_connection)
+from ckan.lib.search.query import (QUERY_FIELDS, VALID_SOLR_PARAMETERS,
+                                   PackageSearchQuery, solr_literal)
+from werkzeug.datastructures import MultiDict
+
+log = logging.getLogger(__name__)
+
+
+class PatchedPackageSearchQuery(PackageSearchQuery):
+    def run(
+        self,
+        query: dict[str, Any],
+        permission_labels: Optional[list[str]] = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """
+        Performs a dataset search using the given query.
+
+        :param query: dictionary with keys like: q, fq, sort, rows, facet
+        :type query: dict
+        :param permission_labels: filter results to those that include at
+            least one of these labels. None to not filter (return everything)
+        :type permission_labels: list of unicode strings; or None
+
+        :returns: dictionary with keys results and count
+
+        May raise SearchQueryError or SearchError.
+        """
+        assert isinstance(query, (dict, MultiDict))
+        # check that query keys are valid
+        if not set(query.keys()) <= VALID_SOLR_PARAMETERS:
+            invalid_params = [s for s in set(query.keys()) - VALID_SOLR_PARAMETERS]
+            raise SearchQueryError("Invalid search parameters: %s" % invalid_params)
+
+        # default query is to return all documents
+        q = query.get("q")
+        if not q or q == '""' or q == "''":
+            query["q"] = "*:*"
+
+        # number of results
+        rows_to_return = int(query.get("rows", 10))
+        # query['rows'] should be a defaulted int, due to schema, but make
+        # certain, for legacy tests
+        if rows_to_return > 0:
+            # #1683 Work around problem of last result being out of order
+            #       in SOLR 1.4
+            rows_to_query = rows_to_return + 1
+        else:
+            rows_to_query = rows_to_return
+        query["rows"] = rows_to_query
+
+        fq = []
+        if "fq" in query:
+            fq.append(query["fq"])
+        fq.extend(query.get("fq_list", []))
+
+        # show only results from this CKAN instance
+        fq.append("+site_id:%s" % solr_literal(config.get("ckan.site_id")))
+
+        # filter for package status
+        if not "+state:" in query.get("fq", ""):
+            fq.append("+state:active")
+
+        # only return things we should be able to see
+        if permission_labels is not None:
+            fq.append(
+                "+permission_labels:(%s)"
+                % " OR ".join(solr_literal(p) for p in permission_labels)
+            )
+        query["fq"] = fq
+
+        # faceting
+        query["facet"] = query.get("facet", "true")
+        query["facet.limit"] = query.get(
+            "facet.limit", config.get("search.facets.limit")
+        )
+        query["facet.mincount"] = query.get("facet.mincount", 1)
+
+        # return the package ID and search scores
+        query["fl"] = query.get("fl", "name")
+
+        # return results as json encoded string
+        query["wt"] = query.get("wt", "json")
+
+        # If the query has a colon in it then consider it a fielded search and do use dismax.
+        defType = query.get("defType", "dismax")
+        if ":" not in query["q"] or defType == "edismax":
+            query["defType"] = defType
+            query["tie"] = query.get("tie", "0.1")
+            # this minimum match is explained
+            # http://wiki.apache.org/solr/DisMaxQParserPlugin#mm_.28Minimum_.27Should.27_Match.29
+            query["mm"] = query.get("mm", "2<-1 5<80%")
+            query["qf"] = query.get("qf", QUERY_FIELDS)
+
+        query.setdefault("df", "text")
+        query.setdefault("q.op", "AND")
+        try:
+            if query["q"].startswith("{!"):
+                raise SearchError("Local parameters are not supported.")
+        except KeyError:
+            pass
+
+        conn = make_connection(decode_dates=False)
+        log.debug("Package query: %r" % query)
+        try:
+            solr_response = conn.search(**query)
+        except pysolr.SolrError as e:
+            # Error with the sort parameter.  You see slightly different
+            # error messages depending on whether the SOLR JSON comes back
+            # or Jetty gets in the way converting it to HTML - not sure why
+            #
+            if e.args and isinstance(e.args[0], str):
+                if (
+                    "Can't determine a Sort Order" in e.args[0]
+                    or "Can't determine Sort Order" in e.args[0]
+                    or "Unknown sort order" in e.args[0]
+                ):
+                    raise SearchQueryError('Invalid "sort" parameter')
+            raise SearchError(
+                "SOLR returned an error running query: %r Error: %r" % (query, e)
+            )
+        self.count = solr_response.hits
+        self.results = cast("list[Any]", solr_response.docs)
+
+        # #1683 Filter out the last row that is sometimes out of order
+        self.results = self.results[:rows_to_return]
+
+        # get any extras and add to 'extras' dict
+        for result in self.results:
+            extra_keys = filter(lambda x: x.startswith("extras_"), result.keys())
+            extras = {}
+            for extra_key in list(extra_keys):
+                value = result.pop(extra_key)
+                extras[extra_key[len("extras_") :]] = value
+            if extra_keys:
+                result["extras"] = extras
+
+        # if just fetching the id or name, return a list instead of a dict
+        if query.get("fl") in ["id", "name"]:
+            self.results = [r.get(query["fl"]) for r in self.results]
+
+        # get facets and convert facets list to a dict
+        self.facets = solr_response.facets.get("facet_fields", {})
+        for field, values in self.facets.items():
+            self.facets[field] = dict(zip(values[0::2], values[1::2]))
+
+        return {"results": self.results, "count": self.count}

--- a/ckanext/gla/templates/package/search.html
+++ b/ckanext/gla/templates/package/search.html
@@ -7,7 +7,7 @@
     {% block secondary_content %}
     {{ super() }}
 
-    <!---- Figure out if there are filters enabled and show clear filters button if so-----!>
+    <!-- Figure out if there are filters enabled and show clear filters button if so -->
     {% set searchstate = namespace(filters_set=false) %}
     {% for filter_name in facet_titles.keys() %}
         {% if filter_name in request.args %}

--- a/ckanext/gla/templates/snippets/package_item.html
+++ b/ckanext/gla/templates/snippets/package_item.html
@@ -10,11 +10,9 @@ Example:
 {% snippet 'snippets/package_item.html', package=c.datasets[0] %}
 
 #}
+
 {% set title = package.title or package.name %}
-{% set notes = h.markdown_extract(package.search_description, extract_length=0) %}
-{% if notes|length == 0 %}
-  {% set notes = h.markdown_extract(package.notes, extract_length=180) %}
-{% endif%}
+
 {% set last_updated = h.last_updated(package) %}
 
 {% set resources_formats = h.dict_list_reduce(package.resources, 'format')%}
@@ -81,7 +79,7 @@ Example:
                                                 'tags': '{{ request.args["tags"] }}',
                                                 'format': '{{ request.args["res_format"] }}',
                                                 'licence': '{{ request.args["license_id"] }}'})">
-          {{title|truncate(80)}}</a>
+          {{title|safe}}</a>
         {% if package.archived == "true" %}[Archived]{% endif %}
         {% endblock %}
         {% block heading_meta %}
@@ -104,15 +102,19 @@ Example:
 
 
     </div>
-    <div class="dataset-source gla-informational">Published by {{package.organization.title}}{% if ns.harvest_source_title %}, hosted by {{ns.harvest_source_title}}{% endif %}</div>
+    <div class="dataset-source gla-informational">Published by {{package.organization.title|safe}}{% if ns.harvest_source_title %}, hosted by {{ns.harvest_source_title}}{% endif %}</div>
     {% endblock %}
     {% block notes %}
-    {% if notes %}
-    <div class="dataset-notes">{{ notes|urlize }}</div>
-    {% else %}
-    <p class="empty">{{ h.humanize_entity_type('package', package.type, 'no description') or _("There is no
-            description for this dataset") }}</p>
-    {% endif %}
+      {% if package.search_description %}
+        <div class="dataset-notes">
+        {% for substring in package.search_description %}
+          {{substring|safe}}
+        {% endfor %}
+        </div>
+      {% else %}
+      <p class="empty">{{ h.humanize_entity_type('package', package.type, 'no description') or _("There is no
+              description for this dataset") }}</p>
+      {% endif %}
     {% endblock %}
     <div class="gla-informational">
       {% if package.entry_type%}


### PR DESCRIPTION
Add search highlighting to title, description and organisation.

https://london.atlassian.net/jira/software/c/projects/DAT/boards/213?selectedIssue=DAT-696

We've had to override two methods and various variables from core CKAN to make this work as CKAN doesn't expose any actions or plugin interfaces to hook into its workflow. The core CKAN code around the search mechanism is not that great so the ideal solution would be to refactor the search mechanism entirely and submit a PR to core CKAN project, however, we don't have enough time on this project get a big PR like that accepted upstream. Another option was to fork CKAN and maintain it ourselves, but this will make upgrades later on more difficult. Our chosen approach keeps all changes isolated to the plugin and easily traversable for future developers.