### PR TITLE
Subtractive text search

### DIFF
--- a/ckanext/gla/search.py
+++ b/ckanext/gla/search.py
@@ -20,7 +20,7 @@ def _empty_or_none(string):
     return string == "" or string is None
 
 def add_quality_to_search(search_params):
-    return {**search_params,
+    return {**search_params
             # NOTE the bf parameter adds these additional boosts into
             # the query/results. There are two numeric fields stored
             # in our dataset records which admins can adjust to
@@ -37,7 +37,8 @@ def add_quality_to_search(search_params):
             #
             # https://nolanlawson.com/2012/06/02/comparing-boost-methods-in-solr/
             # 
-            "bf": f"copy_data_quality^{data_quality_boost_factor} copy_dataset_boost^{dataset_boost_boost_factor}"
+            ,"bf": f"copy_data_quality^{data_quality_boost_factor} copy_dataset_boost^{dataset_boost_boost_factor}"
+
             # NOTE
             #
             # The query field settings shown below are the CKAN
@@ -48,7 +49,7 @@ def add_quality_to_search(search_params):
             # Note also that the text field contains a large amount of
             # metadata copied from other fields in a stemmed form.
 
-            # "qf":"name^4 title^4 tags^2 groups^2 text"
+            #,"qf":"name^4 title^4 tags^2 groups^2 text"
             }
 
 @toolkit.side_effect_free

--- a/ckanext/gla/search.py
+++ b/ckanext/gla/search.py
@@ -39,6 +39,23 @@ def add_quality_to_search(search_params):
             # 
             ,"bf": f"copy_data_quality^{data_quality_boost_factor} copy_dataset_boost^{dataset_boost_boost_factor}"
 
+            # CKANs minimum match default of "2<-1 5<80%"
+            # which means
+            #
+            # - if there are two or fewer query terms both are
+            #   required
+            #
+            # - if there are between 3 and 5 clause all but one term
+            #   is required
+            #
+            # - if there are more than 5 clauses 80% are required
+            #, "mm": "2<-1 5<80%"
+
+            # Override minimum match to require 100% of terms to
+            # match. This essentially makes simple text search always
+            # subtractive (adding more search terms to an existing
+            # query will never return more results)
+            ,"mm": 100
             # NOTE
             #
             # The query field settings shown below are the CKAN


### PR DESCRIPTION
Override CKANs minimum match requirements to require 100% of terms to match. This essentially makes simple text search always subtractive (adding more search terms to an existing query will never return more results).

Prior to this PR CKANs minimum match default is `2<-1 5<80%`

Which translates into english as the following rules:

- if there are two or fewer query terms both are required
- if there are between 3 and 5 terms all but one term is required
- if there are more than 5 terms 80% are required

I've put this change on a PR should we wish to test it later.

It is not currently configurable by an environment variable, though if that is desirable we could potentially add that.