### PR TITLE
Limit text searching to agreed fields and align displayed fields with wireframe

### DIFF
--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -69,6 +69,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
         for result in search_results["results"]:
             result['total_file_size'] = sum(item['size'] for item in result['resources'] if item and item['size'] is not None)
+            result['number_of_files'] = len(result['resources'])
 
             index_id = result.get("index_id", False)
             if index_id and index_id in search_results["highlighting"]:

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -68,8 +68,9 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             return highlighted_field
 
         for result in search_results["results"]:
-            index_id = result.get("index_id", False)
+            result['total_file_size'] = sum(item['size'] for item in result['resources'] if item and item['size'] is not None)
 
+            index_id = result.get("index_id", False)
             if index_id and index_id in search_results["highlighting"]:
                 highlighted_title = _get_highlighted_field("title", index_id)
                 highlighted_notes = _get_highlighted_field("notes", index_id)

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -41,7 +41,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         search_params.update(
             {
                 "hl": "on",
-                "hl.fl": "title,notes,search_description,organization",
+                "hl.fl": "title,notes,search_description",
                 "hl.fragsize": 200,
                 "hl.simple.pre": "[[",
                 "hl.simple.post": "]]",

--- a/ckanext/gla/search.py
+++ b/ckanext/gla/search.py
@@ -20,7 +20,7 @@ def _empty_or_none(string):
     return string == "" or string is None
 
 def add_quality_to_search(search_params):
-    return {**search_params,
+    return {**search_params
             # NOTE the bf parameter adds these additional boosts into
             # the query/results. There are two numeric fields stored
             # in our dataset records which admins can adjust to
@@ -37,7 +37,8 @@ def add_quality_to_search(search_params):
             #
             # https://nolanlawson.com/2012/06/02/comparing-boost-methods-in-solr/
             # 
-            "bf": f"copy_data_quality^{data_quality_boost_factor} copy_dataset_boost^{dataset_boost_boost_factor}"
+            ,"bf": f"copy_data_quality^{data_quality_boost_factor} copy_dataset_boost^{dataset_boost_boost_factor}"
+
             # NOTE
             #
             # The query field settings shown below are the CKAN
@@ -48,7 +49,7 @@ def add_quality_to_search(search_params):
             # Note also that the text field contains a large amount of
             # metadata copied from other fields in a stemmed form.
 
-            # "qf":"name^4 title^4 tags^2 groups^2 text"
+            #,"qf":"name^4 title^4 tags^2 groups^2 text"
             }
 
 @toolkit.side_effect_free

--- a/ckanext/gla/search.py
+++ b/ckanext/gla/search.py
@@ -48,8 +48,9 @@ def add_quality_to_search(search_params):
             #
             # Note also that the text field contains a large amount of
             # metadata copied from other fields in a stemmed form.
-
-            #,"qf":"name^4 title^4 tags^2 groups^2 text"
+            #
+            #,"qf":"name^4 title^4 tags^2 groups^2 text" # CKAN Defaults
+            ,"qf":"title^4,search_description^2,notes" # limit matching of text queries to agreed fields
             }
 
 @toolkit.side_effect_free

--- a/ckanext/gla/templates/snippets/package_item.html
+++ b/ckanext/gla/templates/snippets/package_item.html
@@ -121,7 +121,7 @@ Example:
       {% else %}
         {{ package.number_of_files }} files
       {% endif %}
-      {% if resources_formats|length > 0 %} ({{resources_formats|join(", ") | lower}}) {% endif %} • {% if package.total_file_size != 0 %} {{ h.SI_number_span(package.total_file_size) }} {% else %} Unknown Filesize {% endif %}
+      {% if resources_formats|length > 0 %} ({{resources_formats|sort|join(", ") | lower}}) {% endif %} • {% if package.total_file_size != 0 %} {{ h.SI_number_span(package.total_file_size) }} {% else %} Unknown Filesize {% endif %}
     </div>
   </div>
 

--- a/ckanext/gla/templates/snippets/package_item.html
+++ b/ckanext/gla/templates/snippets/package_item.html
@@ -121,7 +121,7 @@ Example:
       {% else %}
         {{ package.number_of_files }} files
       {% endif %}
-      {% if resources_formats|length > 0 %} ({{resources_formats|sort|join(", ") | lower}}) {% endif %} • {% if package.total_file_size != 0 %} {{ h.SI_number_span(package.total_file_size) }} {% else %} Unknown Filesize {% endif %}
+      {% if resources_formats|length > 0 %} ({{resources_formats|sort|join(", ") | lower}}) {% endif %} • {% if package.total_file_size != 0 %} {{ h.SI_number_span(package.total_file_size) }} {% else %} Unknown Filesize {% endif %} • Expected update unknown
     </div>
   </div>
 

--- a/ckanext/gla/templates/snippets/package_item.html
+++ b/ckanext/gla/templates/snippets/package_item.html
@@ -18,7 +18,7 @@ Example:
 {% set resources_formats = h.dict_list_reduce(package.resources, 'format')%}
 
 {# Workaround in case harvest_source_title doesn't get pulled out of extras #}
-{# variables set inside for loops dont exist outside the loop: https://jinja.palletsprojects.com/en/3.0.x/templates/#assignments  #} 
+{# variables set inside for loops dont exist outside the loop: https://jinja.palletsprojects.com/en/3.0.x/templates/#assignments  #}
 {% set ns = namespace(harvest_source_title=package.harvest_source_title) %}
 {% if harvest_source_title|length == 0 %}
   {% for extra in package.extras %}
@@ -122,12 +122,12 @@ Example:
       {% else %}
         Dataset
       {% endif %}
-      {% if resources_formats|length > 0 %} with {{resources_formats|join(", ") | lower}} {% endif %}
+      {% if resources_formats|length > 0 %} with {{resources_formats|join(", ") | lower}} {% endif %} | {% if package.total_file_size != 0 %} Total File Size {{ h.SI_number_span(package.total_file_size) }} {% else %} Unknown Total Filesize {% endif %}
     </div>
   </div>
 
 
-  
+
   {# {% block resources %}
     {% if package.resources and not hide_resources %}
     {% block resources_outer %}

--- a/ckanext/gla/templates/snippets/package_item.html
+++ b/ckanext/gla/templates/snippets/package_item.html
@@ -92,9 +92,6 @@ Example:
         {% endblock %}
       </h2>
       <div class="dataset-last-updated gla-informational">
-          {% if last_updated %}
-            Updated {{h.localised_nice_date(h.date_str_to_datetime(last_updated))}}
-          {% endif %}
           <span class="small-follow-button">
               {{ h.follow_button('dataset', package.id) }}
           </span>
@@ -102,7 +99,9 @@ Example:
 
 
     </div>
-    <div class="dataset-source gla-informational">Published by {{package.organization.title|safe}}{% if ns.harvest_source_title %}, hosted by {{ns.harvest_source_title}}{% endif %}</div>
+    <div class="dataset-source gla-informational">Published by {{package.organization.title}}
+      {% if last_updated %} • Updated {{h.localised_nice_date(h.date_str_to_datetime(last_updated))}} {% endif %}
+    </div>
     {% endblock %}
     {% block notes %}
       {% if package.search_description %}

--- a/ckanext/gla/templates/snippets/package_item.html
+++ b/ckanext/gla/templates/snippets/package_item.html
@@ -119,9 +119,9 @@ Example:
       {% if package.entry_type%}
         {{package.entry_type|capitalize}}
       {% else %}
-        Dataset
+        {{ package.number_of_files }} files
       {% endif %}
-      {% if resources_formats|length > 0 %} with {{resources_formats|join(", ") | lower}} {% endif %} | {% if package.total_file_size != 0 %} Total File Size {{ h.SI_number_span(package.total_file_size) }} {% else %} Unknown Total Filesize {% endif %}
+      {% if resources_formats|length > 0 %} ({{resources_formats|join(", ") | lower}}) {% endif %} • {% if package.total_file_size != 0 %} {{ h.SI_number_span(package.total_file_size) }} {% else %} Unknown Filesize {% endif %}
     </div>
   </div>
 


### PR DESCRIPTION
This implements the majority of [DAT-706](https://london.atlassian.net/browse/DAT-706) "Search results show relevant content" and all of [DAT-697](https://london.atlassian.net/browse/DAT-697) "Limit text search matching to only fields displayed within search results".  Additionally it aligns the display of metadata more closely with the agreed wireframe on the first issue (706).

Of the five metadata fields mentioned on DAT-706 only the last one is not fully yet implemented, as that information is not currently stored in the index, and will likely require adjustments to the harvester in another PR.  Therefore this PR currently always displays "Expected update unknown" in that area.

- [X] Heading (dataset title)
- [X] Publishing org 
- [X]  Date anything is the dataset was last updated
- [X] Description 
- [X] Total number of files 
- [X] The different file types
- [X] Accumulative file size 
- [ ] update frequency metadata (if not present states 'expected update unknown')

## After PR screenshot

<img width="957" alt="image" src="https://github.com/user-attachments/assets/917b4a84-8257-459b-b512-4e710025072f">


## Before PR screenshot

<img width="877" alt="Screenshot 2024-07-11 at 23 40 27" src="https://github.com/user-attachments/assets/5622bbb4-2748-4969-95e5-b31621a54d70">

