### PR TITLE
Fix regression when running harvesters

### DIFF
--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -68,8 +68,9 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             return highlighted_field
 
         for result in search_results["results"]:
-            result['total_file_size'] = sum(item['size'] for item in result['resources'] if item and item['size'] is not None)
-            result['number_of_files'] = len(result['resources'])
+            resources = result.get('resources',[])
+            result['total_file_size'] = sum(item['size'] for item in resources if item and item['size'] is not None)
+            result['number_of_files'] = len(resources)
 
             index_id = result.get("index_id", False)
             if index_id and index_id in search_results["highlighting"]:

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -38,6 +38,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     def before_dataset_search(self, search_params):
         # Include showcases *and* datasets in the search results:
         # We only want Showcases to show up when there is a search query
+        search_params = search.add_quality_to_search(search_params)
         search_params.update(
             {
                 "hl": "on",

--- a/ckanext/gla/search.py
+++ b/ckanext/gla/search.py
@@ -50,7 +50,7 @@ def add_quality_to_search(search_params):
             # metadata copied from other fields in a stemmed form.
             #
             #,"qf":"name^4 title^4 tags^2 groups^2 text" # CKAN Defaults
-            ,"qf":"title^4,search_description^2,notes" # limit matching of text queries to agreed fields
+            ,"qf":"title^4 search_description^2 notes" # limit matching of text queries to agreed fields
             }
 
 @toolkit.side_effect_free


### PR DESCRIPTION
Fixes two regressions.

1. DAT-697 limiting search to specified fields
2. Highlighting code interferes with harvesting