### PR TITLE
Highlighting bug fix

### DIFF
--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -45,6 +45,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
                 "hl.method": "unified",
                 "hl.fragsizeIsMinimum": "false",
                 "hl.fragsize": 200,
+                "hl.bs.type": "WORD",
                 "hl.fl": "title,notes,search_description",
                 "hl.simple.pre": "[[",
                 "hl.simple.post": "]]",

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -42,8 +42,10 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         search_params.update(
             {
                 "hl": "on",
-                "hl.fl": "title,notes,search_description",
+                "hl.method": "unified",
+                "hl.fragsizeIsMinimum": "false",
                 "hl.fragsize": 200,
+                "hl.fl": "title,notes,search_description",
                 "hl.simple.pre": "[[",
                 "hl.simple.post": "]]",
             }

--- a/ckanext/gla/search_highlight/query.py
+++ b/ckanext/gla/search_highlight/query.py
@@ -13,7 +13,7 @@ from werkzeug.datastructures import MultiDict
 log = logging.getLogger(__name__)
 
 VALID_SOLR_PARAMETERS.update(
-    ["hl", "hl.fl", "hl.fragsize", "hl.simple.pre", "hl.simple.post"]
+    ["hl", "hl.fl", "hl.fragsize", "hl.simple.pre", "hl.simple.post", "hl.method", "hl.fragsizeIsMinimum"]
 )
 
 

--- a/ckanext/gla/search_highlight/query.py
+++ b/ckanext/gla/search_highlight/query.py
@@ -13,7 +13,7 @@ from werkzeug.datastructures import MultiDict
 log = logging.getLogger(__name__)
 
 VALID_SOLR_PARAMETERS.update(
-    ["hl", "hl.fl", "hl.fragsize", "hl.simple.pre", "hl.simple.post", "hl.method", "hl.fragsizeIsMinimum"]
+    ["hl", "hl.fl", "hl.fragsize", "hl.simple.pre", "hl.simple.post", "hl.method", "hl.fragsizeIsMinimum", "hl.bs.type"]
 )
 
 


### PR DESCRIPTION
Fix glitch in highlighting where certain results that matched had no highlighting displayed on the search results page.

Issue was that the SOLR default for the "unified" highlighter appears to be to count fragment size in sentences not words.  And we were then later truncating the matches for display.

Setting this to count in words appears to fix this for the cases we have found.