### PR TITLE
Page heading tweak

### DIFF
--- a/ckanext/gla/templates/ckanext_pages/page.html
+++ b/ckanext/gla/templates/ckanext_pages/page.html
@@ -9,7 +9,6 @@
           {% link_for _('Edit'), named_route='pages.edit', page=c.page.name, class_='btn btn-primary pull-right', icon='edit' %}
       {% endif %}
     {% endblock %}
-    <h1 class="page-heading">{{ c.page.title }}</h1>
       {% block ckanext_pages_content %}
         {% if c.page.content %}
           <div class="ckanext-pages-content">

--- a/ckanext/gla/templates/ckanext_pages/page.html
+++ b/ckanext/gla/templates/ckanext_pages/page.html
@@ -1,0 +1,32 @@
+{% ckan_extends %}
+
+{% block primary %}
+  <section class="module-content">
+
+    {% block ckanext_pages_actions %}
+      {% if h.check_access('ckanext_pages_update') %}
+          {% asset 'pages/main-css' %}
+          {% link_for _('Edit'), named_route='pages.edit', page=c.page.name, class_='btn btn-primary pull-right', icon='edit' %}
+      {% endif %}
+    {% endblock %}
+    <h1 class="page-heading">{{ c.page.title }}</h1>
+      {% block ckanext_pages_content %}
+        {% if c.page.content %}
+          <div class="ckanext-pages-content">
+            {% set editor = h.pages_get_wysiwyg_editor() %}
+            <!-- editor set to "{{ editor }}"-->
+            {% if editor %}
+              <div>
+                  {{c.page.content|safe}}
+              </div>
+            {% else %}
+              {{ h.render_content(c.page.content) }}
+            {% endif %}
+          </div>
+        {% else %}
+          <p class="empty">{{ _('This page currently has no content') }}</p>
+        {% endif %}
+
+      {% endblock %}
+  </section>
+{% endblock %}


### PR DESCRIPTION
Moves responsibility for pages `h1` into the markdown content, decoupling it from the link text in footer anchor tags.