### PR TITLE
DAT-699 make highlighting work with advanced search & DAT-774 highlighting improvements

### DIFF
--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -43,8 +43,9 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         search_params.update(
             {
                 "hl": "on",
-                "hl.method": "original", # Note: Used to be "unified" which is efficient for large documents but an issue came up highlight matched values in title.
+                "hl.method": "unified", 
                 "hl.fragsizeIsMinimum": "false",
+                "hl.requireFieldMatch": "true",
                 "hl.fragsize": 200,
                 "hl.bs.type": "WORD",
                 "hl.fl": "title,notes,search_description",

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -43,7 +43,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         search_params.update(
             {
                 "hl": "on",
-                "hl.method": "unified",
+                "hl.method": "original", # Note: Used to be "unified" which is efficient for large documents but an issue came up highlight matched values in title.
                 "hl.fragsizeIsMinimum": "false",
                 "hl.fragsize": 200,
                 "hl.bs.type": "WORD",

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -46,11 +46,13 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
                 "hl.method": "unified", 
                 "hl.fragsizeIsMinimum": "false",
                 "hl.requireFieldMatch": "true",
-                "hl.fragsize": 200,
-                "hl.bs.type": "WORD",
+                "hl.snippets": "1",
+                "hl.fragsize": "200",
+                "hl.bs.type": "SENTENCE",
                 "hl.fl": "title,notes,search_description",
                 "hl.simple.pre": "[[",
                 "hl.simple.post": "]]",
+                "hl.maxAnalyzedChars": "250000" # only highlight matches occuring in the first 250k characters of a field we increase this from SOLRs default of 51k because some datasets have long descriptions and highlighting wasn't displaying
             }
         )
 
@@ -130,7 +132,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
                 # Handle unclosed tags that flow into the next search result
                 sanitized_search_description = str(
-                    markdown_extract(search_description, extract_length=240)
+                    markdown_extract(search_description, extract_length=500)
                 )
                 sanitized_search_description_list = []
                 for substring in sanitized_search_description.split("[["):

--- a/ckanext/gla/search_highlight/query.py
+++ b/ckanext/gla/search_highlight/query.py
@@ -13,7 +13,7 @@ from werkzeug.datastructures import MultiDict
 log = logging.getLogger(__name__)
 
 VALID_SOLR_PARAMETERS.update(
-    ["hl", "hl.fl", "hl.fragsize", "hl.simple.pre", "hl.simple.post", "hl.method", "hl.fragsizeIsMinimum", "hl.bs.type"]
+    ["hl", "hl.fl", "hl.fragsize", "hl.simple.pre", "hl.simple.post", "hl.method", "hl.fragsizeIsMinimum", "hl.bs.type", "hl.requireFieldMatch"]
 )
 
 

--- a/ckanext/gla/search_highlight/query.py
+++ b/ckanext/gla/search_highlight/query.py
@@ -13,7 +13,7 @@ from werkzeug.datastructures import MultiDict
 log = logging.getLogger(__name__)
 
 VALID_SOLR_PARAMETERS.update(
-    ["hl", "hl.fl", "hl.fragsize", "hl.simple.pre", "hl.simple.post", "hl.method", "hl.fragsizeIsMinimum", "hl.bs.type", "hl.requireFieldMatch"]
+    ["hl", "hl.fl", "hl.fragsize", "hl.simple.pre", "hl.simple.post", "hl.method", "hl.fragsizeIsMinimum", "hl.bs.type", "hl.requireFieldMatch", "hl.snippets", "hl.maxAnalyzedChars", "hl.fragAlignRatio"]
 )
 
 


### PR DESCRIPTION
The method was switched from "unified" to "original" due to an issue with highlighting matched values in titles. While "unified" is more efficient for large documents, resolving the title highlight issue is currently prioritized.