### PR TITLE
fix(dat-805):removed unused hint text from search result template

### DIFF
--- a/ckanext/gla/templates/snippets/search_result_text.html
+++ b/ckanext/gla/templates/snippets/search_result_text.html
@@ -64,10 +64,6 @@
     {% endif %}
     </h1>
 
-    <div class='lead dfl-hint'>
-      Use London’s data to help you understand the city and develop solutions.
-    </div>
-
     {% if type == 'dataset' %}
         {% set text_query = ungettext('Showing {number} result.', 'Showing {number} results.', count) %}
         {% set text_query_none = '' %}


### PR DESCRIPTION
The line reminding users to use London's data has been deleted as it was redundant. This cleans up the interface by avoiding unnecessary information in the search results section.