### PR TITLE
Fix DAT-770: CTRL-clicking a search link changes the search page

### DIFF
--- a/ckanext/gla/assets/search_result_logging.js
+++ b/ckanext/gla/assets/search_result_logging.js
@@ -17,12 +17,24 @@ function postSelectedSearchResult(data) {
     });
 }
 
-
 function logResultClick(event, element, data) {
     if (data["is_search_result"] == "True") {
-        postSelectedSearchResult(data).then(function () {
-            window.location.href = element.getAttribute('href');
-        });
-    }
+        // Check if the click is intended for a new tab or window
+        if (event.ctrlKey || event.shiftKey || event.metaKey || event.button === 1) {
+            // Trigger async logging call whilst also allowing the
+            // default event handler to trigger. We can rely on the
+            // default behaviour as the page will still exist in the
+            // current tab, so the promise will execute.
+            postSelectedSearchResult(data);
+        } else {
+            // Prevent the default anchor click behavior navigating
+            // away from the page before our logging call has finished
+            event.preventDefault();
 
+            postSelectedSearchResult(data).then(function () {
+                // Navigate to the href of the anchor after our logging has occured
+                window.location.href = element.getAttribute('href');
+            });
+        }
+    }
 }


### PR DESCRIPTION
Following this PR this should no longer happen as we now conditionally prevent changing the current pages location depending on if a modifier key was being held.