### PR TITLE
Fix DAT-773 humanize display of file counts to pluralise

### DIFF
--- a/ckanext/gla/templates/snippets/package_item.html
+++ b/ckanext/gla/templates/snippets/package_item.html
@@ -119,9 +119,14 @@ Example:
       {% if package.entry_type%}
         {{package.entry_type|capitalize}}
       {% else %}
-        {{ package.number_of_files }} files
+        {% if package.number_of_files > 0 %}
+          {{ package.number_of_files }} {{ ungettext('file', 'files', package.number_of_files )}}
+        {% endif %}
       {% endif %}
-      {% if resources_formats|length > 0 %} ({{resources_formats|sort|join(", ") | lower}}) {% endif %} • {% if package.total_file_size != 0 %} {{ h.SI_number_span(package.total_file_size) }} {% else %} Unknown Filesize {% endif %} • Expected update unknown
+      {% if resources_formats|length > 0 %} ({{resources_formats|sort|join(", ") | lower}}) {% endif %}
+      {% if package.total_file_size != 0 %}
+        • {{ h.SI_number_span(package.total_file_size) }}
+      {% endif %} • Expected update unknown
     </div>
   </div>
 


### PR DESCRIPTION
The behaviour after this fix is applied is to display either:

- Not display a file count if no files are attached to the dataset
- Display `1 file` as a count if there is 1 file attached to the dataset
- Display `N files` as a count if N is >= 2, e.g. `2 files`.