### PR TITLE
Split high level format groups from file extensions in filter facets

### DIFF
--- a/ckanext/gla/custom_fields.py
+++ b/ckanext/gla/custom_fields.py
@@ -121,6 +121,15 @@ def add_copy_fields():
             add_copy_field(field, new_field)
 
 def add_solr_config():
+
+    if not field_exists('dfl_res_format_group'):
+
+        add_schema({"add-field": {"name": "dfl_res_format_group",
+                                  "type": "string",
+                                  "indexed": True,
+                                  "stored": True,
+                                  "multiValued": True}})
+    
     if not field_exists('dfl_title_sort'):
         add_schema({
             "add-field-type": {

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -172,9 +172,9 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             elif file_format.lower() in GEOSPATIAL_FORMATS:
                 new_format_list.append("Geospatial")
             else:
-                new_format_list.append(file_format)
+                continue #new_format_list.append("Other")
 
-        pkg_dict["res_format"] = new_format_list
+        pkg_dict["dfl_res_format_group"] = new_format_list
 
         return pkg_dict
 
@@ -241,7 +241,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     def dataset_facets(self, facets_dict, _):
         return OrderedDict(
             [
-                ("res_format", facets_dict["res_format"]),
+                ("dfl_res_format_group", toolkit._("Format")),
                 ("organization", facets_dict["organization"]),
                 ("project_name", toolkit._("Projects")),
                 # Entry type is disabled for now as the value is null for harvested datasets
@@ -250,6 +250,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
                 # ("entry_type", toolkit._("Type")),
                 ("london_smallest_geography", toolkit._("Smallest geography")),
                 ("update_frequency", toolkit._("Update frequency")),
+                ("res_format", toolkit._("File type")),
             ]
         )
 


### PR DESCRIPTION
Adds a new facet for Formats that contains only the groups, and presents the low level details in a "File types" facet.

I did consider calling the "File types" facet "File extensions" but upstream sources inconsistently tag these (some using highlevel groupings too).  

<img width="1096" alt="Screenshot 2024-08-12 at 12 34 09" src="https://github.com/user-attachments/assets/dd3c9904-4a8b-492a-b543-95adc0e443a5">
