### PR TITLE
DAT-764: Apply GLA password policy on account creation

### DIFF
--- a/ckanext/gla/auth.py
+++ b/ckanext/gla/auth.py
@@ -1,32 +1,105 @@
 from ckan import authz, model
+from typing import Any
+import string
+import re
+
+import ckan.lib.navl.dictization_functions as df
+from ckan.types import FlattenDataDict, FlattenKey, Context, FlattenErrorDict
+from ckan.common import _
 
 
 def _requester_is_sysadmin(context):
-    requester = context.get('user', None)
+    requester = context.get("user", None)
     return authz.is_sysadmin(requester)
 
+
 def _requester_is_manager(context):
-    requester = context.get('user', None)
-    return authz.has_user_permission_for_some_org(requester,'manage_group')
+    requester = context.get("user", None)
+    return authz.has_user_permission_for_some_org(requester, "manage_group")
+
 
 def user_list(context, data_dict=None):
     """Only sysadmins should be allowed to view the full list of users"""
-    return {'success': _requester_is_sysadmin(context) or _requester_is_manager(context)}
+    return {
+        "success": _requester_is_sysadmin(context) or _requester_is_manager(context)
+    }
 
 
 def user_show(context, data_dict=None):
     """sysadmins can view all user profiles.
     If not a sysadmin, a user can only view their own profile.
-    Based on: https://github.com/qld-gov-au/ckanext-qgov/blob/master/ckanext/qgov/common/auth_functions.py#L126"""
+    Based on: https://github.com/qld-gov-au/ckanext-qgov/blob/master/ckanext/qgov/common/auth_functions.py#L126
+    """
     if _requester_is_sysadmin(context) or _requester_is_manager(context):
-        return {'success': True}
-    requester = context.get('user')
-    id = data_dict.get('id', None)
+        return {"success": True}
+    requester = context.get("user")
+    id = data_dict.get("id", None)
     if id:
         user_obj = model.User.get(id)
     else:
-        user_obj = data_dict.get('user_obj', None)
+        user_obj = data_dict.get("user_obj", None)
     if user_obj:
-        return {'success': requester in [user_obj.name, user_obj.id]}
+        return {"success": requester in [user_obj.name, user_obj.id]}
 
-    return {'success': False}
+    return {"success": False}
+
+
+def has_consecutive_numbers(password_string):
+    # Regular expression to find consecutive numbers
+    pattern = r"(?=(\d)(\d)(\d))"
+    matches = re.findall(pattern, password_string)
+
+    for match in matches:
+        # Convert the matched string to a list of integers
+        numbers = list(map(int, match))
+
+        # Check if they are consecutive
+        if all(numbers[i] + 1 == numbers[i + 1] for i in range(len(numbers) - 1)):
+            return True
+    return False
+
+
+def user_password_validator(
+    key: FlattenKey, data: FlattenDataDict, errors: FlattenErrorDict, context: Context
+) -> Any:
+    """Ensures that password is safe enough."""
+    value = data[key]
+
+    if isinstance(value, df.Missing):
+        pass
+    elif not isinstance(value, str):
+        errors[("password",)].append(_("Passwords must be strings"))
+    elif value == "":
+        pass
+    elif len(value) < 13:
+        errors[("password",)].append(_("Your password must be 13 characters or longer"))
+    elif isinstance(value, str):
+        rules = [
+            any(x.isupper() for x in value),
+            any(x.islower() for x in value),
+            any(x.isdigit() for x in value),
+            any(x in string.punctuation for x in value),
+        ]
+
+        if sum(rules) != 4:
+            errors[("password",)].append(
+                _(
+                    "Your password must contain at least one of each of the following: upper case character, lower case character, number and a non alpha character (e.g. !$#,%)"
+                )
+            )
+    elif data.get(("name",)) in value or data.get(("fullname",)) in value:
+        errors[("password",)].append(
+            _("Your password shouldn't contain your username or full name")
+        )
+    elif has_consecutive_numbers(value):
+        errors[("password",)].append(
+            _("Your password must not contain consecutive numbers such as '123'")
+        )
+    else:
+        for password_char in value:
+            if password_char * 3 in value:
+                errors[("password",)].append(
+                    _(
+                        'Your password must not contain repeating characters such as "aaa"'
+                    )
+                )

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -3,9 +3,10 @@ from typing import Any
 
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
+from ckan.common import _
 from ckan.config.declaration import Declaration, Key
 from ckan.lib.helpers import markdown_extract
-from ckan.types import Schema
+from ckan.types import Schema, Validator
 from markupsafe import Markup
 
 from . import auth, custom_fields, helpers, search, timestamps, views
@@ -27,6 +28,10 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IDatasetForm)
     plugins.implements(plugins.IFacets)
+    plugins.implements(plugins.IValidators)
+
+    def get_validators(self) -> dict[str, Validator]:
+        return {"user_password_validator": auth.user_password_validator}
 
     # IConfigDeclaration
     def declare_config_options(self, declaration: Declaration, key: Key):
@@ -73,7 +78,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     def before_dataset_view(self, package_dict):
         for extra in package_dict.get("extras", []):
             if extra["key"] == "update_frequency":
-                package_dict["update_frequency_label"] = extra['value']
+                package_dict["update_frequency_label"] = extra["value"]
                 break
 
         return package_dict


### PR DESCRIPTION
Password policy is in [DAT-764](https://london.atlassian.net/browse/DAT-764).  

The interpretation and items we've implemented are:

1. ✅ Password must not contain their login name
1.  ✅ Password must not contain their display name
1. ✅ Must contain at least one of each of the following: upper case character, lower case character, number and a non alpha character (e.g. !$#,%)
1.  ✅ Must not contain repeating characters (e.g. aaa, etc...) 
1. ✅ Must not contain 3 or more consecutive digits e.g. 123, 789, 456 etc...
1. ✅ Must contain at least 13 characters 