### PR TITLE
fix(dat-778):Fix typo in account deletion instructions

### DIFF
--- a/ckanext/gla/templates/user/edit_user_form.html
+++ b/ckanext/gla/templates/user/edit_user_form.html
@@ -36,7 +36,7 @@
       <div class="delete-account">
           <h6>Delete account</h6>
           <p>
-              If you wish to delete your account, please <a href="mailto:datastore@london.gov.uk">email the site administrator</a> from the email address associated with your acocunt.
+              If you wish to delete your account, please <a href="mailto:datastore@london.gov.uk">email the site administrator</a> from the email address associated with your account.
               All personal data will be removed from our systems upon request in accordance with GDPR regulation. Further information can be found in the <a href="/about/privacy-policy">Privacy Policy</a>.
           </p>
       </div>


### PR DESCRIPTION
Corrected a typo in the 'Delete account' section of the user edit form, changing 'acocunt' to 'account'. This ensures clear communication to users seeking to delete their accounts.