### PR TITLE
Feature/dat 777  add hyperlink to reset password email

### DIFF
--- a/ckanext/gla/email.py
+++ b/ckanext/gla/email.py
@@ -1,0 +1,29 @@
+from ckan import model
+import ckan.lib.mailer as Mailer
+from ckan.lib.base import render
+from ckan.common import config
+
+def get_reset_link_html_body(user: model.User) -> str:
+    extra_vars = {
+        'reset_link': Mailer.get_reset_link(user),
+        'site_title': config.get('ckan.site_title'),
+        'site_url': config.get('ckan.site_url'),
+        'user_name': user.name,
+    }
+    return render('emails/reset_password.html', extra_vars)
+
+# Override ckan's send_reset_link function to pass body_html into mail_user
+# So that the email will be sent as multipart/alternative with both a plain text version and a html version
+def send_reset_link(user: model.User) -> None:
+    Mailer.create_reset_key(user)
+    body = Mailer.get_reset_link_body(user)
+    body_html = get_reset_link_html_body(user)
+    extra_vars = {
+        'site_title': config.get('ckan.site_title')
+    }
+    subject = render('emails/reset_password_subject.txt', extra_vars)
+
+    # Make sure we only use the first line
+    subject = subject.split('\n')[0]
+
+    Mailer.mail_user(user, subject, body, body_html)

--- a/ckanext/gla/email.py
+++ b/ckanext/gla/email.py
@@ -13,7 +13,7 @@ def get_reset_link_html_body(user: model.User) -> str:
     return render('emails/reset_password.html', extra_vars)
 
 # Override ckan's send_reset_link function to pass body_html into mail_user
-# So that the email will be sent as multipart/alternative with both a plain text version and a html version
+# So that the password reset link email will be sent as multipart/alternative with both a plain text version and a html version
 def send_reset_link(user: model.User) -> None:
     Mailer.create_reset_key(user)
     body = Mailer.get_reset_link_body(user)

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -3,11 +3,13 @@ from typing import Any
 
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
+import ckan.lib.mailer as Mailer
 from ckan.common import _
 from ckan.config.declaration import Declaration, Key
 from ckan.lib.helpers import markdown_extract, ungettext, dict_list_reduce
 from ckan.types import Schema, Validator
 from markupsafe import Markup
+from .email import send_reset_link
 
 from . import auth, custom_fields, helpers, search, timestamps, views
 from .search_highlight import action, query
@@ -16,6 +18,8 @@ TABLE_FORMATS = toolkit.config.get("ckan.harvesters.table_formats").split(" ")
 REPORT_FORMATS = toolkit.config.get("ckan.harvesters.report_formats").split(" ")
 GEOSPATIAL_FORMATS = toolkit.config.get("ckan.harvesters.geospatial_formats").split(" ")
 
+# Add html template to password reset email
+Mailer.send_reset_link = send_reset_link
 
 class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     plugins.implements(plugins.IConfigurer)

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -18,7 +18,7 @@ TABLE_FORMATS = toolkit.config.get("ckan.harvesters.table_formats").split(" ")
 REPORT_FORMATS = toolkit.config.get("ckan.harvesters.report_formats").split(" ")
 GEOSPATIAL_FORMATS = toolkit.config.get("ckan.harvesters.geospatial_formats").split(" ")
 
-# Add html template to password reset email
+# Override this function to add a html template to password reset link email
 Mailer.send_reset_link = send_reset_link
 
 class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):

--- a/ckanext/gla/templates/emails/reset_password.html
+++ b/ckanext/gla/templates/emails/reset_password.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Reset password link</title>
+  </head>
+  <body>
+    <p>Dear {{ user_name }},</p>
+    <p>You have requested your password on {{ site_title }} to be reset.</p>
+    <p>
+      Please click the following link to confirm this request:
+      <a href="{{ reset_link }}" target="_blank">{{ reset_link }}</a>
+    </p>
+    <p>Have a nice day.</p>
+    <p>--<br />Message sent by {{ site_title }} (<a href="{{ site_url }}" target="_blank">{{ site_url }}</a>)</p>
+  </body>
+</html>


### PR DESCRIPTION
- create reset_password.html template
- override ckan mailer library send_reset_link function to send html as well as plain text