### PR TITLE
DAT-803 Reset password link error page

### DIFF
--- a/ckanext/gla/templates/error_document_template.html
+++ b/ckanext/gla/templates/error_document_template.html
@@ -1,0 +1,10 @@
+{% ckan_extends %}
+
+
+{% block primary %}
+  {% if code == 403 and _('Invalid reset key. Please try again.') in content %}
+    <h1 style="padding-top: 32px">Your reset password link has expired or already been used. Please {{ h.link_to('request another reset link', '/user/reset') }}.</h1>
+  {% else %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}

--- a/ckanext/gla/templates/error_document_template.html
+++ b/ckanext/gla/templates/error_document_template.html
@@ -3,7 +3,7 @@
 
 {% block primary %}
   {% if code == 403 and _('Invalid reset key. Please try again.') in content %}
-    <h1 style="padding-top: 32px">Your reset password link has expired or already been used. Please {{ h.link_to('request another reset link', '/user/reset') }}.</h1>
+    <p style="padding-top: 32px">Your reset password link has expired or already been used. Please {{ h.link_to('request another reset link', '/user/reset') }}.</p>
   {% else %}
     {{ super() }}
   {% endif %}


### PR DESCRIPTION
- Display a custom error message for 403 invalid reset key error.