### PR TITLE
Fix DAT-825 if ajax log call fails the page load is prevented

### DIFF
--- a/ckanext/gla/assets/search_result_logging.js
+++ b/ckanext/gla/assets/search_result_logging.js
@@ -29,9 +29,9 @@ function logResultClick(event, element, data) {
         } else {
             // Prevent the default anchor click behavior navigating
             // away from the page before our logging call has finished
-            event.preventDefault();
+	    event.preventDefault();
 
-            postSelectedSearchResult(data).then(function () {
+            postSelectedSearchResult(data).finally(function() {
                 // Navigate to the href of the anchor after our logging has occured
                 window.location.href = element.getAttribute('href');
             });


### PR DESCRIPTION
See issue: https://london.atlassian.net/browse/DAT-825

Related to: https://london.atlassian.net/browse/DAT-770