### PR TITLE
Align facets on organisation and group pages with main search page

### DIFF
--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -373,10 +373,10 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         return GLA_DATASET_FACETS
 
     def organization_facets(self, facets_dict, *args):
-        return facets_dict
+        return GLA_DATASET_FACETS
 
     def group_facets(self, facets_dict, *args):
-        return facets_dict
+        return GLA_DATASET_FACETS
 
     # IAuthenticator
 


### PR DESCRIPTION
Fix facets on the organisation and group pages.  These are typically only used in management flows.

- [ ] TODO fix organisation pages to show filter summary (this will be done a future PR)