### PR TITLE
DAT-763 trusted email rules for private datasets + audit features

### DIFF
--- a/ckanext/gla/helpers.py
+++ b/ckanext/gla/helpers.py
@@ -6,9 +6,16 @@ import bleach
 from bs4 import BeautifulSoup
 from markupsafe import Markup
 
+from typing import (
+    Any, Callable, Match, NoReturn, cast, Dict,
+    Iterable, Optional, TypeVar, Union)
+
+import ckan.logic as logic
+
 import ckan.lib.formatters as formatters
 import ckan.plugins.toolkit as toolkit
-from ckan.common import _, config
+from ckan.common import _, config, current_user
+from ckan.model.user import AnonymousUser
 from ckan.lib.helpers import get_translated
 from ckan.lib.helpers import render_markdown as original_render_markdown
 
@@ -193,7 +200,21 @@ def resource_display_name(resource_dict: dict[str, Any]) -> str:
     else:
         return _("Unnamed resource")
 
+def orgs_list_for_user(user: str, permission: str = 'read') -> list[dict[str, Any]]:
+    '''Return a list of organizations that the current user has the specified
+    permission for.
+    '''
+    context: Context = {'user': user}
+    data_dict = { 'permission': permission}
+    orgs = logic.get_action('organization_list_for_user')(context, data_dict)    
+    return orgs
 
+def is_sysadmin():
+    if not isinstance(current_user, AnonymousUser) and current_user.sysadmin:
+        return True
+    else:
+        return False
+    
 def get_helpers():
     return {
         "get_followed_datasets": followed,
@@ -206,4 +227,6 @@ def get_helpers():
         "humanise_file_size": humanise_file_size,
         "render_markdown": render_markdown,
         "resource_display_name": resource_display_name,
+        "orgs_list_for_user": orgs_list_for_user,
+        "is_sysadmin": is_sysadmin
     }

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -325,6 +325,15 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultPerm
                     sanitized_search_description_list
                 )
 
+        search_facets = search_results['search_facets']
+
+        if 'private' in search_facets:
+            for i in search_facets['private']['items']:
+                if i['display_name'] == 'true':
+                    i['display_name'] = 'Private'
+                else:
+                    i['display_name'] = 'Public'
+
         return search_results
 
     def after_dataset_create(self, ctx, package):

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -400,7 +400,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultPerm
             "log_chosen_search_result": search.log_selected_result,
             "package_search": action.package_search,
             "user_create": user.user_create,
-            "user_list": user.user_list
+            "user_list": user.user_list        
         }
 
     # IDatasetForm

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -363,7 +363,14 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultPerm
 
     # ITemplateHelpers
     def get_helpers(self):
-        return helpers.get_helpers()
+
+        def is_trusted_email(user_obj):
+            return any(re.search(pattern, user_obj.email) for pattern in TRUSTED_EMAIL_REGEXES)
+        
+        h = {'is_trusted_email': is_trusted_email,
+             'is_email_verified': auth.is_email_verified}
+        
+        return helpers.get_helpers() | h
 
     # IBlueprint
     def get_blueprint(self):
@@ -376,6 +383,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultPerm
             "log_chosen_search_result": search.log_selected_result,
             "package_search": action.package_search,
             "user_create": user.user_create,
+            "user_list": user.user_list
         }
 
     # IDatasetForm
@@ -541,3 +549,4 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultPerm
                 labels.append(u'dfl_trusted_email_access')
             
         return labels
+

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -375,9 +375,17 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultPerm
 
         def is_trusted_email(user_obj):
             return any(re.search(pattern, user_obj.email) for pattern in TRUSTED_EMAIL_REGEXES)
+
+        def org_opt_outs():
+            return TRUSTED_EMAIL_ORG_OPT_OUTS
+
+        def is_org_opted_out(org):
+            return org in TRUSTED_EMAIL_ORG_OPT_OUTS
         
         h = {'is_trusted_email': is_trusted_email,
-             'is_email_verified': auth.is_email_verified}
+             'is_email_verified': auth.is_email_verified,
+             'is_org_opted_out': is_org_opted_out,
+             'org_opt_outs': org_opt_outs}
         
         return helpers.get_helpers() | h
 

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -7,13 +7,16 @@ from markupsafe import Markup
 
 import ckan.lib.mailer as Mailer
 import ckan.plugins as plugins
+from ckan.lib.plugins import DefaultPermissionLabels
 import ckan.plugins.toolkit as toolkit
 from ckan.common import _, request
 from ckan.config.declaration import Declaration, Key
 from ckan.lib import signals
 from ckan.lib.helpers import dict_list_reduce, markdown_extract, ungettext
-from ckan.model import User
+from ckan.model import User, AnonymousUser, Group
+from ckan.model.meta import Session
 from ckan.types import Schema, Validator
+from ckan.plugins.toolkit import get_action
 
 from . import auth, custom_fields, helpers, search, timestamps, user, views
 from .email import send_email_verification_link, send_reset_link
@@ -26,6 +29,17 @@ from .search_highlight.action import dataset_facets_for_user, GLA_SYSADMIN_FACET
 TABLE_FORMATS = toolkit.config.get("ckan.harvesters.table_formats").split(" ")
 REPORT_FORMATS = toolkit.config.get("ckan.harvesters.report_formats").split(" ")
 GEOSPATIAL_FORMATS = toolkit.config.get("ckan.harvesters.geospatial_formats").split(" ")
+
+def load_config_as_list(key):
+    val = toolkit.config.get(key,'')
+    if val:
+        return list(filter(lambda x: x != '', val.split(' ')))
+    else:
+        return []
+        
+
+TRUSTED_EMAIL_REGEXES = load_config_as_list("dfl.trusted-email-access.regexes")
+TRUSTED_EMAIL_ORG_OPT_OUTS = set(load_config_as_list("dfl.trusted-email-access.optout-org-slugs"))
 
 # Override this function to add a html template to password reset link email
 Mailer.send_reset_link = send_reset_link
@@ -99,7 +113,7 @@ def is_multi_select_route(path):
     return False
     
 
-class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
+class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultPermissionLabels):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IConfigDeclaration)
     plugins.implements(plugins.IAuthFunctions, inherit=True)
@@ -112,7 +126,8 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     plugins.implements(plugins.IDatasetForm)
     plugins.implements(plugins.IFacets)
     plugins.implements(plugins.IValidators)
-
+    plugins.implements(plugins.IPermissionLabels)
+    
     def get_validators(self) -> dict[str, Validator]:
         return {"user_password_validator": auth.user_password_validator}
 
@@ -451,3 +466,78 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         signals.failed_login.send(login)
 
         return None
+
+
+    def get_dataset_labels(self, dataset_obj: Any) -> list[str]:
+        u'''
+
+        This method works with the corresponding method
+        `get_user_dataset_labels`, it is part of CKANs extension API
+        it is hooked into by DFL to provide the
+        `dfl_trusted_email_access` label, which allows users with
+        eligible email addresses to view all private datasets in the
+        system published by organisations who have not opted out.
+
+        Organisations who have opted out, as identified by their
+        organisation slug, should be space separated in the ckan
+        config value `dfl.trusted-email-access.optout-org-slugs`.
+        Datasets published by organisations with these identifiers
+        will not be tagged with the `dfl_trusted_email_access` tag.
+       
+        This method is called during indexing of a dataset, to
+        return a list of permission_labels to be associated
+        with the supplied dataset.  These labels are then stored
+        in the search index and form part of CKANs SOLR queries to ensure
+        only datasets that a user has permission to access are returned.
+
+        The algorithm is simple; datasets have many permission_labels
+        and users have many permission_labels, and if there is a non
+        empty set intersection between a datasets labels and a users
+        labels then the user has permission to view that dataset.
+
+        '''
+
+        default_labels = super(GlaPlugin, self).get_dataset_labels(dataset_obj)
+        
+        if not dataset_obj.private:
+            return default_labels
+        else:
+            dataset_org_name = Session.query(Group).filter(Group.id==dataset_obj.owner_org).first().name
+            if dataset_org_name in TRUSTED_EMAIL_ORG_OPT_OUTS:
+                return default_labels
+            else: 
+                return default_labels + [u'dfl_trusted_email_access']        
+        
+
+    def get_user_dataset_labels(self, user_obj: Any) -> list[str]:
+        u'''
+        This method works with the corresponding `get_dataset_labels`
+        method, and forms part of CKANs extension API.
+
+        This method may be called before datasets are loaded from the
+        SOLR index or before candidate datasets are shown to a user.
+
+        The set of labels returned are compared against a
+        corresponding set of labels on a dataset and if they return a
+        non empty intersection then the dataset can be viewed by the
+        given user.
+
+        We hook into this method to dynamically determine whether a
+        users verified email address matches one of the regexes in
+        `dfl.trusted-email-access.regexes` if so they are given the
+        `dfl_trusted_email_access` label which means they can view
+        private datasets from any organisation that has not opted out
+        of this feature.
+
+        Opt outs are handled in the corresponding `get_dataset_labels`
+        method.
+        '''
+        labels = super(GlaPlugin, self).get_user_dataset_labels(user_obj)        
+        
+        if user_obj and not isinstance(user_obj, AnonymousUser):
+            has_matching_email = any(re.search(pattern, user_obj.email) for pattern in TRUSTED_EMAIL_REGEXES) 
+            
+            if(has_matching_email and auth.is_email_verified(user_obj)):
+                labels.append(u'dfl_trusted_email_access')
+            
+        return labels

--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -632,6 +632,23 @@ input[type="checkbox"] {
     right: 10px;
 }
 
+ul.inline-list {
+      list-style-type: none; /* Remove default list styling */
+      /* padding: 0; */
+      /* margin: 0;     */
+}
+
+
+    /* Display list items inline */
+    ul.inline-list li {
+        display: inline;
+    }
+
+    /* Add comma after each list item except the last one */
+    ul.inline-list li:not(:last-child)::after {
+        content: ", ";
+    }
+
 /* Pagination */
 
 ul.pagination {

--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -1014,11 +1014,11 @@ form.lang-select select {
 }
 
 
-.resource-item .resource-description { 
+.resource-item .resource-description {
     color: var(--t-colors-grey);
 }
-.resource-item .resource-meta { 
-    
+.resource-item .resource-meta {
+
     color: var(--t-colors-grey);
     font-size: 0.8rem;}
 
@@ -1595,10 +1595,10 @@ div#followee-filter {
 #dataset-resources, #additional-info {
     margin-top: 3em;
     padding-top: 1.5rem;
-    
+
 }
 
-#dataset-resources { 
+#dataset-resources {
     border-top: 1px solid var(--t-colors-grey-50);
 }
 
@@ -1685,7 +1685,7 @@ padding-top: 24px;
 margin-bottom: 16px;
 }
 
-.checkbox-filter { 
+.checkbox-filter {
 cursor: pointer;
 }
 
@@ -1708,6 +1708,11 @@ justify-content: space-between;
 padding-left: 15px;
 padding-right: 15px;
 position: relative;
+}
+
+table.dfl-scroll-table {
+    display: block;
+    overflow-x: auto;
 }
 
 .inner-btn-content {

--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -649,6 +649,10 @@ ul.inline-list {
         content: ", ";
     }
 
+li.no-bullet {
+    list-style-type: none;
+}
+
 /* Pagination */
 
 ul.pagination {

--- a/ckanext/gla/templates/organization/read.html
+++ b/ckanext/gla/templates/organization/read.html
@@ -19,9 +19,14 @@
 {% block upper_content %}
 <div class="row">
     <div class="col-md-3">
-        <img class=org-page-image src="{{group_dict.image_display_url}}" />
+      <img class=org-page-image src="{{group_dict.image_display_url}}" />
     </div>
     <div class="col-md-9 col-xs-12">
+      {% if h.is_org_opted_out(group_dict.name) and h.check_access('organization_update', {'id': group_dict.id}) %}
+      <div class="alert alert-success">
+        <strong>Private Data Sharing: </strong> This organisation has opted out from sharing information on private datasets with users with trusted email addresses.
+      </div>
+      {% endif %}
         {% block form %}
         {% set facets = {
           'fields': fields_grouped,

--- a/ckanext/gla/templates/user/list.html
+++ b/ckanext/gla/templates/user/list.html
@@ -6,9 +6,12 @@
       <thead>
         <tr>
           <th>User</th>
+          <th>User Type</th>
           <th>Email</th>
-          <th>Email Verified</th>
-          <th>Has Trusted Email</th>
+          <th>Verified Email</th>
+          <th>Trusted Email</th>
+          <th>Organisation Member</th>
+          <th>Dataset Collaborator</th>
         </tr>
       </thead>
       <tbody>
@@ -16,10 +19,12 @@
           {% for user in page.items %}
             <tr>
               <td class="media">{{ h.linked_user(user['name'], maxlength=20) }}</td>
+              <td>{% if user.sysadmin %} Sys Admin {% else %} Standard {% endif %}</td>
               <td>{{ user['email'] }}</td>
               <td>{{ h.is_email_verified(user) }}</td>
               <td>{{ h.is_trusted_email(user) }}</td>
-
+              <td>{{ user.is_organization_member }}</td>
+              <td>{{ user.is_collaborator }}</td>
             </tr>
       {% endfor %}
       {% endblock %}

--- a/ckanext/gla/templates/user/list.html
+++ b/ckanext/gla/templates/user/list.html
@@ -2,13 +2,30 @@
 {% block users_list %}
   {% set no_results_text = _('No matching result for "{q}".').format(q=q) %}
   {% if page.items %}
-    <ul class="user-list">
-      {% block users_list_inner %}
-        {% for user in page.items %}
-          <li>{{ h.linked_user(user['name'], maxlength=20) }}</li>
-        {% endfor %}
+    <table class="table table-header table-hover table-bordered">
+      <thead>
+        <tr>
+          <th>User</th>
+          <th>Email</th>
+          <th>Email Verified</th>
+          <th>Has Trusted Email</th>
+        </tr>
+      </thead>
+      <tbody>
+          {% block users_list_inner %}
+          {% for user in page.items %}
+            <tr>
+              <td class="media">{{ h.linked_user(user['name'], maxlength=20) }}</td>
+              <td>{{ user['email'] }}</td>
+              <td>{{ h.is_email_verified(user) }}</td>
+              <td>{{ h.is_trusted_email(user) }}</td>
+
+            </tr>
+      {% endfor %}
       {% endblock %}
-    </ul>
+
+    </tbody>
+  </table>
   {% else %}
     <p>{{ _(no_results_text) }}</p>
   {% endif %}

--- a/ckanext/gla/templates/user/list.html
+++ b/ckanext/gla/templates/user/list.html
@@ -2,12 +2,12 @@
 {% block users_list %}
   {% set no_results_text = _('No matching result for "{q}".').format(q=q) %}
   {% if page.items %}
-    <table class="table table-header table-hover table-bordered">
+    <table class="table table-header table-hover table-bordered dfl-scroll-table">
       <thead>
         <tr>
-          <th>User</th>
-          <th>User Type</th>
+          <th>Username</th>
           <th>Email</th>
+          <th>User Type</th>
           <th>Verified Email</th>
           <th>Trusted Email</th>
           <th>Organisation Member</th>
@@ -17,10 +17,10 @@
       <tbody>
           {% block users_list_inner %}
           {% for user in page.items %}
-            <tr>
-              <td class="media">{{ h.linked_user(user['name'], maxlength=20) }}</td>
-              <td>{% if user.sysadmin %} Sys Admin {% else %} Standard {% endif %}</td>
+          <tr>
+              <td><a href="{{ url_for('user.read', id=user['name'])}}"> {{ user['name'] }}</a></td>
               <td>{{ user['email'] }}</td>
+              <td>{% if user.sysadmin %} Sys&nbsp;Admin {% else %} Standard {% endif %}</td>
               <td>{{ h.is_email_verified(user) }}</td>
               <td>{{ h.is_trusted_email(user) }}</td>
               <td>{{ user.is_organization_member }}</td>
@@ -28,7 +28,6 @@
             </tr>
       {% endfor %}
       {% endblock %}
-
     </tbody>
   </table>
   {% else %}

--- a/ckanext/gla/templates/user/list.html
+++ b/ckanext/gla/templates/user/list.html
@@ -34,3 +34,24 @@
     <p>{{ _(no_results_text) }}</p>
   {% endif %}
 {% endblock %}
+
+{% block page_pagination %}
+    {{ page.pager(q=q, order_by=order_by) }}
+
+<p>
+  <strong>Note:</strong>
+  {% if h.org_opt_outs() %}
+  The following organisations have opted out of sharing private datasets with users with trusted email addresses:
+
+  <ul class='inline-list'>
+    {% for opt_out in h.org_opt_outs()|sort %}
+      <li><a href="{{ url_for('organization.read',id=opt_out)}}">{{ opt_out }}</a></li>
+    {% endfor %}
+  </ul>
+
+  {% else %}
+    No organisations have opted out of sharing private datasets with users with trusted email addresses.
+  {% endif %}
+</p>
+
+{% endblock %}

--- a/ckanext/gla/templates/user/read.html
+++ b/ckanext/gla/templates/user/read.html
@@ -7,6 +7,22 @@
 </li>
 {% endblock %}
 
-{% block primary_content_inner %}
-{% endblock %}
 
+{% block primary_content_inner %}
+
+{% if h.is_sysadmin() %}
+  {% set orgs = h.orgs_list_for_user(user.name)|sort(attribute='title') %}
+
+{% if orgs %}
+    <p>This user is a member of the following organisations:</p>
+    <ul>
+    {% for org in orgs %}
+      <li class="no-bullet"><a href="{{ url_for('organization.read',id=org.name)}}">{{ org.title }}</a></li>
+    {% endfor %}
+    </ul>
+  {% else %}
+    <p>This user is not a member of any organisations</p>
+  {% endif %}
+
+{% endif %}
+{% endblock %}

--- a/ckanext/gla/templates/user/read_base.html
+++ b/ckanext/gla/templates/user/read_base.html
@@ -3,13 +3,11 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-{% if orgs_available %}
-        {{ h.build_nav_icon('user.read_organizations', h.humanize_entity_type('organization', org_type, 'content tab') or _('Organizations'), id=user.name, icon='building') }}
-    {% endif %}
-    {% if h.check_access('api_token_list', {'user': user['name']}) %}
-        {{ h.build_nav_icon('user.api_tokens', _('API Tokens'), id=user.name, icon='key') }}
-    {% endif %}
+  {% if h.is_sysadmin() %}
+    {{ h.build_nav_icon('user.read', _('Organisations'), id=user.name, icon='building') }}
+  {% endif %}
+
+  {% if h.check_access('api_token_list', {'user': user['name']}) %}
+    {{ h.build_nav_icon('user.api_tokens', _('API Tokens'), id=user.name, icon='key') }}
+  {% endif %}
 {% endblock %}
-
-
-

--- a/ckanext/gla/user.py
+++ b/ckanext/gla/user.py
@@ -1,9 +1,15 @@
 import ckan.lib.helpers as h
 import ckan.model as model
+from ckan.model.user import User
+
 import ckan.plugins.toolkit as toolkit
 from ckan.common import logout_user, request
 from ckan.types import Response
 from ckan.views.user import RegisterView
+
+import sqlalchemy as sa
+from sqlalchemy.sql import exists
+
 
 from . import email
 
@@ -35,3 +41,13 @@ def user_create(original_action, context, data_dict):
     data_dict["name"] = data_dict.get("name").lower()
     result = original_action(context, data_dict)
     return result
+
+
+@toolkit.chained_action
+def user_list(original_action, context, data_dict):
+    query = original_action(context, data_dict)
+    
+    # Modify the query to add the 'plugin_extras' field from the User model
+    query = query.add_columns(User.plugin_extras)
+
+    return query

--- a/ckanext/gla/user.py
+++ b/ckanext/gla/user.py
@@ -1,18 +1,21 @@
 import ckan.lib.helpers as h
+import ckan.lib.dictization.model_dictize as model_dictize
 import ckan.model as model
 from ckan.model.user import User
 from ckan.model.group import Member, Group
 from ckan.model.package import PackageMember
 
 import ckan.plugins.toolkit as toolkit
-from ckan.common import logout_user, request
+from ckan.types import ActionResult
+
+from ckan.common import asbool, logout_user, request
 from ckan.types import Response
 from ckan.views.user import RegisterView
 
 import sqlalchemy as sa
 from sqlalchemy.sql import exists
 
-
+from .auth import is_email_verified
 from . import email
 
 
@@ -47,7 +50,7 @@ def user_create(original_action, context, data_dict):
 
 @toolkit.chained_action
 def user_list(original_action, context, data_dict):
-    query = original_action(context, data_dict)
+    query = original_action(context | {'return_query': True}, data_dict)
 
     # Modify CKAN query to return extra information to assist admins in auditing users
     is_org_member = sa.case(
@@ -64,7 +67,23 @@ def user_list(original_action, context, data_dict):
             PackageMember.capacity == 'member',
             PackageMember.package_id.isnot(None)
         )), True)], else_=False).label('is_collaborator')
+
     
     query = query.add_columns(User.sysadmin, User.plugin_extras, is_org_member, is_collaborator)    
 
-    return query
+    if context.get('return_query'):
+        return query
+    else:
+        # an API request so run query and dictize results
+        users_list: ActionResult.UserList = []
+        all_fields = asbool(data_dict.get('all_fields', None))
+        
+        for user in query.all():                
+            result_dict = model_dictize.user_dictize(user[0], context)
+            result_dict['is_collaborator'] = user.is_collaborator
+            result_dict['is_email_verified'] = is_email_verified(user)
+            result_dict['is_organization_member'] = user.is_organization_member
+            
+            users_list.append(result_dict)
+        
+        return users_list


### PR DESCRIPTION
Implements [DAT-763](https://london.atlassian.net/browse/DAT-763):

* Users with verified email addresses which match any of a list of configured regular expressions can view private datasets across organisations unless those organisations are part of the opt out list.  The regular expressions are space separated in the ckan config value `dfl.trusted-email-access.regexes` provided in the ckan ini file.
  **NOTE:** changing this config value and deploying as normal is all that is necessary to activate the change.
* Organisations can opt out of the above rule, by having their org slug specified (space separated) in the config value `dfl.trusted-email-access.optout-org-slugs`.
    **NOTE:** if this value is modified the SOLR search index will need to be rebuilt for this change to apply with the command `docker exec -it ckan ckan search-index rebuild`

The following changes have also been made to support auditing:

1. The `/users` page (available only to sysadmins) now displays a table of users with information necessary to determine if they can access private datasets.  Additionally a list of opted out organisations are displayed on this page.
    <img width="1353" alt="Screenshot 2024-09-23 at 14 52 12" src="https://github.com/user-attachments/assets/1d2829f8-61b1-42b4-87ed-d8450378a90e">
2. If the signed in user is a sysadmin clicking a user in the above table will take them to the users page which now contains a list of organisations of which that user is a member:
   <img width="1068" alt="Screenshot 2024-09-24 at 10 27 41" src="https://github.com/user-attachments/assets/16e2fe84-19fc-4abc-ab71-c7f266a8ba1a">
3. If an organisation has opted out of sharing private dataset details with trusted users, then the following message is displayed to sysadmins or admins of that organisation:
    <img width="1319" alt="Screenshot 2024-09-23 at 14 51 36" src="https://github.com/user-attachments/assets/8152dd54-7084-4546-ba81-70ef55787902">
4. If a user is signed in as a sysadmin the `Dataset Visibility` values now display as either `Public` or `Private` not `true` or `false`.
    <img width="379" alt="Screenshot 2024-09-24 at 11 29 34" src="https://github.com/user-attachments/assets/4c62d302-0ba9-4f87-a414-46e34f3e85db">
