### PR TITLE
Email verification fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,12 @@ To install ckanext-gla:
 
 ## Config settings
 
-None at present
+This plugin exposes the following configuration options via
+environment variables:
 
-**TODO:** Document any optional config settings here. For example:
+- `EMAIL_VERIFICATION_SECURITY_KEY` Secret key used for cryptographic tokens.
+- `EMAIL_VERIFICATION_TOKEN_EXPIRY` Expiry time in seconds for email verification tokens default `86400`
 
-	# The minimum number of hours to wait before re-checking a resource
-	# (optional, default: 24).
-	ckanext.gla.some_setting = some_default_value
 
 
 ## Developer installation

--- a/README.md
+++ b/README.md
@@ -2,8 +2,23 @@
 
 # ckanext-gla
 
-**TODO:** Put a description of your extension here:  What does it do? What features does it have? Consider including some screenshots or embedding a video!
+CKAN customisations for the Data for London datastore.
 
+## Config settings
+
+This plugin exposes the following configuration options via
+environment variables:
+
+- `EMAIL_VERIFICATION_SECURITY_KEY` Secret key used for cryptographic tokens.
+- `EMAIL_VERIFICATION_TOKEN_EXPIRY` Expiry time in seconds for email verification tokens default `86400`
+
+through `ckan.ini` and `custom_options.ini` you can customise the following options:
+
+- `ckan.harvesters.table_formats` space separated list of file formats to classify as "Tables" under the "Format" facet.
+- `ckan.harvesters.report_formats` space separated list of file formats to classify as "Reports" under the "Format" facet.
+- `ckan.harvesters.geospatial_formats` space separated list of file formats to classify as "Geospatial" under the "Format" facet.
+- `dfl.trusted-email-access.regexes` space separated list of regular expressions to determine if a verified email address is trusted (and can access private datasets).
+- `dfl.trusted-email-access.optout-org-slugs` space separated list of organisation slugs to determine if an organisation opts out of the above trusted email access feature.
 
 ## Requirements
 
@@ -56,22 +71,6 @@ To install ckanext-gla:
 
      sudo service apache2 reload
 
-
-## Config settings
-
-This plugin exposes the following configuration options via
-environment variables:
-
-- `EMAIL_VERIFICATION_SECURITY_KEY` Secret key used for cryptographic tokens.
-- `EMAIL_VERIFICATION_TOKEN_EXPIRY` Expiry time in seconds for email verification tokens default `86400`
-
-through `ckan.ini` and `custom_options.ini` you can customise the following options:
-
-- `ckan.harvesters.table_formats` space separated list of file formats to classify as "Tables" under the "Format" facet.
-- `ckan.harvesters.report_formats` space separated list of file formats to classify as "Reports" under the "Format" facet.
-- `ckan.harvesters.geospatial_formats` space separated list of file formats to classify as "Geospatial" under the "Format" facet.
-- `dfl.trusted-email-access.regexes` space separated list of regular expressions to determine if a verified email address is trusted (and can access private datasets).
-- `dfl.trusted-email-access.optout-org-slugs` space separated list of organisation slugs to determine if an organisation opts out of the above trusted email access feature.
 
 ## Developer installation
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ environment variables:
 - `EMAIL_VERIFICATION_SECURITY_KEY` Secret key used for cryptographic tokens.
 - `EMAIL_VERIFICATION_TOKEN_EXPIRY` Expiry time in seconds for email verification tokens default `86400`
 
+through `ckan.ini` and `custom_options.ini` you can customise the following options:
 
+- `ckan.harvesters.table_formats` space separated list of file formats to classify as "Tables" under the "Format" facet.
+- `ckan.harvesters.report_formats` space separated list of file formats to classify as "Reports" under the "Format" facet.
+- `ckan.harvesters.geospatial_formats` space separated list of file formats to classify as "Geospatial" under the "Format" facet.
+- `dfl.trusted-email-access.regexes` space separated list of regular expressions to determine if a verified email address is trusted (and can access private datasets).
+- `dfl.trusted-email-access.optout-org-slugs` space separated list of organisation slugs to determine if an organisation opts out of the above trusted email access feature.
 
 ## Developer installation
 

--- a/ckanext/gla/auth.py
+++ b/ckanext/gla/auth.py
@@ -16,8 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 SECRET_KEY = os.environ.get("EMAIL_VERIFICATION_SECURITY_KEY")
-SECURITY_PASSWORD_SALT = os.environ.get("EMAIL_VERIFICATION_SECURITY_PASSWORD_SALT")
-
 
 def _requester_is_sysadmin(context):
     requester = context.get("user", None)
@@ -128,11 +126,11 @@ def user_password_validator(
 
 def generate_token(email: str) -> str:
     serializer = URLSafeTimedSerializer(SECRET_KEY)
-    return serializer.dumps(email, salt=SECURITY_PASSWORD_SALT)
+    return serializer.dumps(email, salt="email-verification-token")
 
 def read_email_from_token(token,max_age=None):
     serializer = URLSafeTimedSerializer(SECRET_KEY)
-    email = serializer.loads(token, salt=SECURITY_PASSWORD_SALT, max_age=max_age)
+    email = serializer.loads(token, salt="email-verification-token", max_age=max_age)
     return email 
 
 def verify_user(token, expiration=86400) -> str:

--- a/ckanext/gla/templates/error_document_template.html
+++ b/ckanext/gla/templates/error_document_template.html
@@ -1,15 +1,19 @@
 {% ckan_extends %}
 
-{% if code == 403 and _('Email not verified') in content %}
-    {%- block title -%}
-        {%- block subtitle %}{% endblock -%}
+{%- block title -%}
+   {% if code == 403 and _('Email not verified') in content %}
+        Verify Email - {{ g.site_title }}
+   {% else %}
+        {%- block subtitle %}{{ super() }}{% endblock -%}
         {%- if self.subtitle()|trim %} {{ g.template_title_delimiter }} {% endif -%}
-        Verify Email
-      {%- endblock -%}
-{% endif %}
+        {{ g.site_title }}
+   {% endif %}
+{%- endblock -%}
+
+
 
 {% block primary %}
-  {% if code == 403 and _('Invalid reset key. Please try again.') in content %}
+{% if code == 403 and _('Invalid reset key. Please try again.') in content %}
     <p style="padding-top: 32px">Your reset password link has expired or already been used. Please {{ h.link_to('request another reset link', '/user/reset') }}.</p>
   {% elif code == 403 and _('Email not verified') in content %}
     <div style="padding-top: 32px">

--- a/ckanext/gla/user.py
+++ b/ckanext/gla/user.py
@@ -19,26 +19,79 @@ from .auth import is_email_verified
 from . import email
 
 
+import ckan.logic as logic
+import ckan.lib.base as base
+from ckan import authz
+from ckan.common import (
+    _, config, g, current_user, login_user
+)
+
+from typing import Any, Optional, Union
+import ckan.lib.captcha as captcha
+import ckan.lib.navl.dictization_functions as dictization_functions
+
 class GlaRegisterView(RegisterView):
-    def post(self) -> Response | str:
-        super().post()
+    # Code taken from:
+    # https://github.com/ckan/ckan/blob/9915ba0022b9a74a65e61c097b2fee584b044087/ckan/views/user.py#L420-L476
+    def post(self) -> Union[Response, str]:        
+        context = self._prepare()
+        try:
+            data_dict = logic.clean_dict(
+                dictization_functions.unflatten(
+                    logic.tuplize_dict(logic.parse_params(request.form))))
+            data_dict.update(logic.clean_dict(
+                dictization_functions.unflatten(
+                    logic.tuplize_dict(logic.parse_params(request.files)))
+            ))
 
-        # Send verification email and log the user out
-        user_email = request.form.get("email")
-        if user_email:
-            user_obj = model.User.by_email(user_email)
-            if user_obj:
-                email.send_email_verification_link(user_obj)
+        except dictization_functions.DataError:
+            base.abort(400, _(u'Integrity Error'))
 
-        logout_user()
+        try:
+            captcha.check_recaptcha(request)
+        except captcha.CaptchaError:
+            error_msg = _(u'Bad Captcha. Please try again.')
+            h.flash_error(error_msg)
+            return self.get(data_dict)
 
-        h.flash_notice(
-            "A verification email has been sent to your email address. Please click the link in the email to verify your email address."
-        )
+        try:
+            user_dict = logic.get_action(u'user_create')(context, data_dict)
+        except logic.NotAuthorized:
+            base.abort(403, _(u'Unauthorized to create user %s') % u'')
+        except logic.NotFound:
+            base.abort(404, _(u'User not found'))
+        except logic.ValidationError as e:
+            errors = e.error_dict
+            error_summary = e.error_summary
+                
+            return self.get(data_dict, errors, error_summary)
 
-        return h.redirect_to("user.login")
+        user = current_user.name
+        if user:
+            # #1799 User has managed to register whilst logged in - warn user
+            # they are not re-logged in as new user.
+            h.flash_success(
+                _(u'User "%s" is now registered but you are still '
+                  u'logged in as "%s" from before') % (data_dict[u'name'],
+                                                       user))
+            if authz.is_sysadmin(user):
+                # the sysadmin created a new user. We redirect him to the
+                # activity page for the newly created user
+                if "activity" in g.plugins:
+                    return h.redirect_to(
+                        u'activity.user_activity', id=data_dict[u'name'])
+                return h.redirect_to(u'user.read', id=data_dict[u'name'])
+            else:
+                return base.render(u'user/logout_first.html')
+        # log the user in programatically
+        userobj = model.User.get(user_dict["id"])
+        if userobj:
+            login_user(userobj)
+            rotate_token()
+        resp = h.redirect_to(u'user.me')
+        return resp    
 
-
+    
 @toolkit.chained_action
 def user_create(original_action, context, data_dict):
     # Force username and email to be lower case

--- a/ckanext/gla/views.py
+++ b/ckanext/gla/views.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from os.path import exists
 from typing import Any, cast
 
@@ -22,6 +23,10 @@ favourites = Blueprint("favourites_blueprint", __name__)
 users = Blueprint("users_blueprint", __name__)
 search_log_download = Blueprint("search_log_download_blueprint", __name__)
 undelete = Blueprint("undelete_blueprint", __name__)
+
+# Note this expiry time is measured in seconds
+# Default is 2 days
+EMAIL_VERIFICATION_TOKEN_EXPIRY = int(os.environ.get("EMAIL_VERIFICATION_TOKEN_EXPIRY","86400"))
 
 
 def show_favourites():
@@ -134,7 +139,7 @@ def view_user(id):
     return base.render("user/read.html", extra_vars)
 
 
-def verify_user(token, expiration=86400):
+def verify_user(token, expiration=EMAIL_VERIFICATION_TOKEN_EXPIRY):
     """
     Verify a user's email address by checking that a GET request is made with a valid token.
     """


### PR DESCRIPTION
Fixes:

- DAT-843 title for 404 page is wrong
- Reports multiple validation errors per field, e.g. on the password field
- DAT-843 email verification message shown when validation fails
- DAT-838 expired validation key returns 500 and also improve handling of other classes of exception

Adds: 

- Configuration of email verification expiry time via env var `EMAIL_VERIFICATION_TOKEN_EXPIRY` 