### PR TITLE
DAT-781 temporal coverage

### DIFF
--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import re
@@ -248,6 +249,20 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultPerm
                 break
 
         package_dict["gla_result_summary"] = " • ".join(gla_information)
+
+        def convert_iso_to_ddmmyyyy(date_str):
+            try:
+                date_obj = datetime.datetime.strptime(date_str, '%Y-%m-%d')
+                return date_obj.strftime('%d/%m/%Y')
+            except ValueError:
+                return None
+
+        for resource in package_dict.get("resources",[]):
+            if resource.get('temporal_coverage_from'):
+                resource['temporal_coverage_from'] = convert_iso_to_ddmmyyyy(resource.get('temporal_coverage_from'))
+            if resource.get('temporal_coverage_to'):
+                resource['temporal_coverage_to'] = convert_iso_to_ddmmyyyy(resource.get('temporal_coverage_to'))
+        
         return package_dict
 
     def after_dataset_search(
@@ -472,7 +487,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultPerm
             'temporal_coverage_to' : [ toolkit.get_validator('ignore_missing'),
                                        toolkit.get_validator('isodate_string')]
         })
-        #breakpoint()
+        
         return schema
 
     def is_fallback(self):

--- a/ckanext/gla/templates/package/snippets/resource_item.html
+++ b/ckanext/gla/templates/package/snippets/resource_item.html
@@ -1,8 +1,6 @@
 <tr class="govuk-table__row">
-    <td scope="row" class="govuk-table__cell">
-        <p>
-            {{ h.resource_display_name(res) | truncate(50) }}
-        </p>
+  <td scope="row" class="govuk-table__cell">
+        <p><strong>{{ h.resource_display_name(res) | truncate(50) }}</strong></p>
 
         {% if res.description %}
             <p>

--- a/ckanext/gla/templates/package/snippets/resource_item.html
+++ b/ckanext/gla/templates/package/snippets/resource_item.html
@@ -79,10 +79,19 @@
         {% endif %}
     </td>
 
-    {# Add from and to dates here #}
+    <td class="govuk-table__cell" style="white-space: nowrap;">
+        {% if res.temporal_coverage_from %}
+            {{ res.temporal_coverage_from }}
+        {% endif %}
+    </td>
+
+   <td class="govuk-table__cell" style="white-space: nowrap;">
+       {% if res.temporal_coverage_to %}
+          {{ res.temporal_coverage_to }}
+       {% endif %}
+    </td>
 
     <td class="govuk-table__cell">
         <a href="{{ res.url }}" class="btn btn-default">Download</a>
     </td>
-
 </tr>

--- a/ckanext/gla/templates/package/snippets/resources_list.html
+++ b/ckanext/gla/templates/package/snippets/resources_list.html
@@ -16,13 +16,15 @@
         {% endif %}
 
         {% set can_edit = can_edit or h.check_access('package_update', {'id':pkg.id }) %}
-        
+
         <table class="govuk-table">
             <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                     <th scope="col" class="govuk-table__header"></th>
                     <th scope="col" class="govuk-table__header">Type</th>
                     <th scope="col" class="govuk-table__header">Size</th>
+                    <th scope="col" class="govuk-table__header">From</th>
+                    <th scope="col" class="govuk-table__header">To</th>
                     <th scope="col" class="govuk-table__header"></th>
                 </tr>
             </thead>


### PR DESCRIPTION
Updates to schemas and front end to display temporal coverage metadata on resource table.

Goes with https://github.com/GreaterLondonAuthority/dfl-ckanext-havester/pull/18