### PR TITLE
Fix DAT-851 Make python API calls triggering dataset_search work

### DIFF
--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -30,6 +30,8 @@ from .search_highlight.action import dataset_facets_for_user, GLA_SYSADMIN_FACET
 
 from .login import ( login )
 
+from flask import has_request_context
+
 TABLE_FORMATS = toolkit.config.get("ckan.harvesters.table_formats").split(" ")
 REPORT_FORMATS = toolkit.config.get("ckan.harvesters.report_formats").split(" ")
 GEOSPATIAL_FORMATS = toolkit.config.get("ckan.harvesters.geospatial_formats").split(" ")
@@ -110,10 +112,11 @@ MULTI_SELECT_ROUTES = [
     r'^/organization/bulk_process(/[^/]+/?)?$'
 ]
 
-def is_multi_select_route(path):
-    for r in MULTI_SELECT_ROUTES:
-        if re.match(r,path):
-            return True
+def is_multi_select_route(request):
+    if has_request_context(): # be mindful that some API requests are not over HTTP but via the python action API
+       for r in MULTI_SELECT_ROUTES:
+           if re.match(r,request.path):
+               return True
     return False
 
 def isodate_string(value, context):
@@ -165,7 +168,7 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultPerm
         # We only want Showcases to show up when there is a search query
         search_params = search.add_quality_to_search(search_params)
 
-        if is_multi_select_route(request.path):
+        if is_multi_select_route(request):
             # If we're not an API request or a query running on the
             # harvester extension routes trigger the multi-select
             # faceted search behaviour.

--- a/ckanext/gla/search_highlight/action.py
+++ b/ckanext/gla/search_highlight/action.py
@@ -15,6 +15,8 @@ from ckan.logic.action.get import ValidationError, _check_access, _validate
 from ckan.types import ActionResult, Context, DataDict
 from collections import OrderedDict
 
+from flask import has_request_context
+
 log = logging.getLogger(__name__)
 
 GLA_DATASET_FACETS = OrderedDict(
@@ -37,6 +39,8 @@ GLA_SYSADMIN_FACETS = GLA_DATASET_FACETS.copy()
 GLA_SYSADMIN_FACETS.update({'private': toolkit._("Dataset Visibility")})
 
 def dataset_facets_for_user():
+    # Note this function assumes we have checked has_request_context
+    # before triggering it.
     if not isinstance(current_user, AnonymousUser) and current_user.sysadmin:
         return GLA_SYSADMIN_FACETS
     else:
@@ -44,9 +48,10 @@ def dataset_facets_for_user():
 
 def selected_facets():
     facets_selected = {}
-    for (facet_id) in dataset_facets_for_user():
-        if facet_id in request.args:
-            facets_selected[facet_id] = request.args.getlist(facet_id)
+    if has_request_context():
+       for (facet_id) in dataset_facets_for_user():
+           if facet_id in request.args:
+               facets_selected[facet_id] = request.args.getlist(facet_id)
     return facets_selected
 
 # Filter facets so values are only provided for those that have


### PR DESCRIPTION
It looks like the multi-select facet work caused this regression causing failures in the fetch/gather-consumer and possibly search index rebuild.

Add checks that we're in the HTTP context before enabling features that require information from the HTTP request.