### PR TITLE
DAT-785 migrate existing organisations from old id to new (part 1)

### DIFF
--- a/ckanext/gla/auth.py
+++ b/ckanext/gla/auth.py
@@ -33,7 +33,6 @@ def user_list(context, data_dict=None):
         "success": _requester_is_sysadmin(context) or _requester_is_manager(context)
     }
 
-
 def user_show(context, data_dict=None):
     """sysadmins can view all user profiles.
     If not a sysadmin, a user can only view their own profile.

--- a/ckanext/gla/organization.py
+++ b/ckanext/gla/organization.py
@@ -74,7 +74,7 @@ def migrate(context, data_dict={}):
                                 'organization_id': new_org["id"]
                             }
                         )
-                        print(f"dataset updated '{dataset['id']}'")
+                        log.info(f"dataset updated '{dataset['id']}'")
                     except BaseException as e:
                         log.warning(f"FAILED to update dataset for org '{dataset['owner_org']}' for ID '{dataset['id']}'.")
 

--- a/ckanext/gla/organization.py
+++ b/ckanext/gla/organization.py
@@ -1,0 +1,109 @@
+import logging
+import os
+from os.path import exists
+from typing import Any, cast
+import ckan
+import ckan.model as model
+import ckan.plugins.toolkit as tk
+from . import auth, email
+import ckan.plugins.toolkit as toolkit
+import csv
+from ckan import authz
+import ckan.lib.base as base
+from ckan.common import _
+
+log = logging.getLogger(__name__)
+
+ORGAINZATION_DICT = {}
+try:
+    with open("organisation_mappings.csv", mode='r') as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            ORGAINZATION_DICT[row["Original ID"]] = row["Override ID"]
+except:
+    log.debug("Opening CSV failed")
+
+@toolkit.auth_disallow_anonymous_access
+def migrate(context, data_dict={}): 
+
+    requester = context.get("user", None)
+    
+    if not authz.is_sysadmin(requester):
+        return base.abort(403, _("Not authorized to see this page"))
+
+    base_context = {
+        "model": model,
+        "session": model.Session,
+        "user": "ckan_admin",
+    }
+
+    print("START")
+
+    organizations = toolkit.get_action("organization_list")(data_dict={})
+
+    for organization in organizations:
+
+        print(organization)
+
+        org_mapping = ORGAINZATION_DICT.get(organization, "")
+
+        if org_mapping != "":
+
+            new_org = None
+
+            try:
+                new_org = toolkit.get_action('organization_show')(data_dict={'id': org_mapping})
+            except toolkit.ObjectNotFound:
+                current_org = toolkit.get_action('organization_show')(data_dict={'id': organization})
+                org_data_dict = {
+                    'name': org_mapping,
+                    'title': org_mapping, 
+                    "id": org_mapping,
+                    'description': current_org["description"],
+                    'image_url' : current_org["image_url"],
+                    'is_organization': True,
+                    'state': 'active'
+                }
+                new_org = toolkit.get_action('organization_create')(base_context, org_data_dict)
+                log.info("Organization %s has been newly created", org_mapping)
+
+            datasets = get_datasets_by_org(organization, base_context)
+
+            for dataset in datasets:
+                    try:
+                        toolkit.get_action('package_owner_org_update')(
+                            base_context,
+                            {
+                                'id': dataset["id"],  # Dataset ID
+                                'organization_id': new_org["id"]  # New organization ID
+                            }
+                        )
+                        print(f"dataset updated '{dataset['id']}'")
+                    except BaseException as e:
+                        log.warning(f"FAILED to update dataset for org '{dataset['owner_org']}' for ID '{dataset['id']}'.")
+                        print(e)
+
+
+            remaining_datasets = get_datasets_by_org(organization, base_context)
+            if not remaining_datasets:
+                try:
+                    toolkit.get_action('organization_delete')(base_context, {'id': organization})
+                    log.info(f"Old organization '{organization}' deleted.")
+                except:
+                    log.warning(f"FAILED to delete old organization '{organization}' as it still has datasets.")
+            else:
+                log.warning(f"Old organization '{organization}' still has datasets and cannot be deleted.")
+
+    return "get_migrate_organizations completed"
+
+def get_datasets_by_org(org_name, context):
+    search_result = toolkit.get_action('package_search')(
+    context, {
+        'fq': f'organization:{org_name}', 
+        'rows': 1000,
+        'include_private': True,   # Include private datasets
+        'include_drafts': True,    # Include drafts or inactive datasets
+        'include_deleted': True    # Include deleted datasets
+        }
+    )
+    return search_result['results']

--- a/ckanext/gla/organization.py
+++ b/ckanext/gla/organization.py
@@ -15,13 +15,16 @@ from ckan.common import _
 log = logging.getLogger(__name__)
 
 ORGANIZATION_DICT = {}
+
 try:
     with open("organisation_mappings.csv", mode='r',encoding='utf-8-sig') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             ORGANIZATION_DICT[row["Original ID"]] = row["Override ID"]
-except:
-    log.debug("Opening CSV failed")
+    log.info("organisation_mappings.csv is loaded, run ckan_action_migrate_organization.sh to canonicalise organisation mappings")
+
+except FileNotFoundError:
+    log.info("No organisation_mappings.csv are available")
 
 @toolkit.auth_disallow_anonymous_access
 def migrate(context, data_dict={}):     

--- a/ckanext/gla/organization.py
+++ b/ckanext/gla/organization.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 ORGAINZATION_DICT = {}
 try:
-    with open("organisation_mappings.csv", mode='r') as csvfile:
+    with open("organisation_mappings.csv", mode='r',encoding='utf-8-sig') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             ORGAINZATION_DICT[row["Original ID"]] = row["Override ID"]

--- a/ckanext/gla/organization.py
+++ b/ckanext/gla/organization.py
@@ -37,13 +37,9 @@ def migrate(context, data_dict={}):
         "user": "ckan_admin",
     }
 
-    print("START")
-
     organizations = toolkit.get_action("organization_list")(data_dict={})
 
     for organization in organizations:
-
-        print(organization)
 
         org_mapping = ORGAINZATION_DICT.get(organization, "")
 
@@ -74,15 +70,13 @@ def migrate(context, data_dict={}):
                         toolkit.get_action('package_owner_org_update')(
                             base_context,
                             {
-                                'id': dataset["id"],  # Dataset ID
-                                'organization_id': new_org["id"]  # New organization ID
+                                'id': dataset["id"], 
+                                'organization_id': new_org["id"]
                             }
                         )
                         print(f"dataset updated '{dataset['id']}'")
                     except BaseException as e:
                         log.warning(f"FAILED to update dataset for org '{dataset['owner_org']}' for ID '{dataset['id']}'.")
-                        print(e)
-
 
             remaining_datasets = get_datasets_by_org(organization, base_context)
             if not remaining_datasets:
@@ -101,9 +95,9 @@ def get_datasets_by_org(org_name, context):
     context, {
         'fq': f'organization:{org_name}', 
         'rows': 1000,
-        'include_private': True,   # Include private datasets
-        'include_drafts': True,    # Include drafts or inactive datasets
-        'include_deleted': True    # Include deleted datasets
+        'include_private': True,
+        'include_drafts': True,
+        'include_deleted': True
         }
     )
     return search_result['results']

--- a/ckanext/gla/organization.py
+++ b/ckanext/gla/organization.py
@@ -14,18 +14,17 @@ from ckan.common import _
 
 log = logging.getLogger(__name__)
 
-ORGAINZATION_DICT = {}
+ORGANIZATION_DICT = {}
 try:
     with open("organisation_mappings.csv", mode='r',encoding='utf-8-sig') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            ORGAINZATION_DICT[row["Original ID"]] = row["Override ID"]
+            ORGANIZATION_DICT[row["Original ID"]] = row["Override ID"]
 except:
     log.debug("Opening CSV failed")
 
 @toolkit.auth_disallow_anonymous_access
-def migrate(context, data_dict={}): 
-
+def migrate(context, data_dict={}):     
     requester = context.get("user", None)
     
     if not authz.is_sysadmin(requester):
@@ -41,7 +40,7 @@ def migrate(context, data_dict={}):
 
     for organization in organizations:
 
-        org_mapping = ORGAINZATION_DICT.get(organization, "")
+        org_mapping = ORGANIZATION_DICT.get(organization, "")
 
         if org_mapping != "":
 

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -20,7 +20,7 @@ from ckan.types import Schema, Validator
 from ckan.plugins.toolkit import get_action
 from ckan.logic.validators import isodate
 
-from . import auth, custom_fields, helpers, search, timestamps, user, views
+from . import auth, custom_fields, helpers, search, timestamps, user, views, organization
 from .email import send_email_verification_link, send_reset_link
 from .search_highlight import (  # query is imported for initialisation, though not explicitly used
     action,
@@ -427,7 +427,8 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultPerm
             "log_chosen_search_result": search.log_selected_result,
             "package_search": action.package_search,
             "user_create": user.user_create,
-            "user_list": user.user_list
+            "user_list": user.user_list,
+            "migrate_organization": organization.migrate     
         }
 
 

--- a/ckanext/gla/views.py
+++ b/ckanext/gla/views.py
@@ -10,14 +10,12 @@ import ckan.logic as logic
 import ckan.model as model
 import ckan.plugins.toolkit as tk
 from ckan import authz
-from ckan.common import _, current_user, g
+from ckan.common import _, current_user, g, request
 from ckan.types import Context
 from flask import Blueprint, send_file
 from itsdangerous.exc import SignatureExpired, BadData
 from . import auth, email
-
 log = logging.getLogger(__name__)
-
 
 favourites = Blueprint("favourites_blueprint", __name__)
 users = Blueprint("users_blueprint", __name__)

--- a/ckanext/gla/views.py
+++ b/ckanext/gla/views.py
@@ -10,7 +10,7 @@ import ckan.logic as logic
 import ckan.model as model
 import ckan.plugins.toolkit as tk
 from ckan import authz
-from ckan.common import _, current_user, g, request
+from ckan.common import _, current_user, g
 from ckan.types import Context
 from flask import Blueprint, send_file
 from itsdangerous.exc import SignatureExpired, BadData


### PR DESCRIPTION
- Implements a migrate process as part of DAT-785 to migrate old organisations (previously ingested) to a new canonicalised ID.  This process can be triggered by issuing an HTTP `POST` request with the correct authz to the new migrate route `/api/3/action/migrate_organization`.  The route has access to the `.csv` file of mappings so it doesn't need any parameters.  [A script which triggers this and a reindex can be found here ](https://github.com/GreaterLondonAuthority/Data_for_London/blob/develop/scripts/shell/ckan_action_migrate_organization.sh) in the top level repository.

- The other side of this (preventing duplication of organisations due to uncanonicalised IDs in the first place) is handled in this harvester PR https://github.com/GreaterLondonAuthority/dfl-ckanext-havester/pull/17