### PR TITLE
DAT-752 Rewrite HTML tags in dataset/package description for consistency

### DIFF
--- a/ckanext/gla/helpers.py
+++ b/ckanext/gla/helpers.py
@@ -3,6 +3,7 @@ import re
 from typing import Any
 
 import bleach
+
 from bs4 import BeautifulSoup
 from markupsafe import Markup
 
@@ -123,21 +124,107 @@ def get_site_title(request):
     else:
         return None
 
+allow_listed_tag_attrs = {
+        'h1':[],
+        'h2':[],
+        'h3':[],
+        'h4':[],
+        'h5':[],
+        'h6':[],
+        'h7':[],
+        'a': ['href'],
+        'strong': [],
+        'em': [],
+        'ul': [],
+        'li': [],
+        'ol': [],
+        'table': [],
+        'tr': [],
+        'th': [],
+        'td': [],
+        'thead': [],
+        'tbody': [],
+        'tfoot': [],
+        'caption': [],
+        'div':[],  # TODO consider
+        'img': ['alt','src'],
+        'iframe': ['src'],
+        'iframe':['src'],
+        'p':['class'] # Temporarily allowed but post filter later for specific classes only e.g. dfl_trusted_email_access
+}
 
-def sanitise_markup_for_dataset_page(html: str, pkg_dict) -> str:
+ALLOWED_PROTOCOLS = ['http', 'https', 'mailto', 'data'] # NOTE we don't really allow 'data' we replace it later in post filtering
+
+def sanitise_markup_for_dataset_page(html: str, pkg_dict: dict[str, Any]) -> str:
+    """Sanitise and fix markup in HTML strings for rendering on the
+    dataset page.
+
+    NOTE: we need to allow a subset of markup through for rendering,
+    so we clean it and then post process the cleaned html as best we
+    can.
+
     """
-    Sanitise and fix markup in HTML strings.
-    """
+
+    if not html:
+        return ''
+
+    # Bleach sanitises HTML string by removing unsafe tags and attributes.
+    # It also removes mismatched tags.
+    # NOTE: CSS in style arrtibutes isn't sanitised but can be added through additional dependencies,
+    # see bleach.CSS_SANITIZER.
+
+    html = bleach.clean(html,strip=True, strip_comments=True, attributes=allow_listed_tag_attrs, tags=allow_listed_tag_attrs.keys(),
+                        protocols=ALLOWED_PROTOCOLS)
+
     soup = BeautifulSoup(html, "lxml")
 
-    for data in soup(["style", "script", "iframe", "br"]):
-        data.decompose()
+    for data in soup(allow_listed_tag_attrs.keys()):
+        # If the tag is in the whitelist, filter its attributes
+        if data.name == 'iframe':
+            print(f'Replacing iframe data URLs %s' % pkg_dict.get('name'))
+            # Replace iframe with a link
+            iframe_src = data.get('src', '#')
+            replacement_tag= soup.new_tag("p")
+            replacement_tag.string = "This description contains embedded content "
 
-    return str(soup)
+            # Create <a> tag with href attribute
+            a_tag = soup.new_tag("a", href=iframe_src)
+            a_tag.string = "that can be viewed here"
+            replacement_tag.append(a_tag)
+            replacement_tag.append('.')
+
+            data.replace_with(replacement_tag)
+        elif data.name == 'img' and data.get('src','').startswith('data:'):
+            print(f'Replacing img data URLs %s' % pkg_dict.get('name'))
+            replacement_tag = soup.new_tag('p', **{'class': 'dfl_replaced_image'})
+            replacement_tag.append("[an embedded image cannot be displayed here - ")
+            a_tag = soup.new_tag('a', href=pkg_dict['upstream_url'])
+            a_tag.string = 'view on source site'
+            replacement_tag.append(a_tag)
+            replacement_tag.append(']')
+            data.replace_with(replacement_tag)
+        elif data.name in ['h1','h2','h3','h4','h5','h6','h7']:
+            print(f'Replacing heading with consistent one')
+            text = ''.join(str(child) for child in data.children)
+            text = bleach.clean(text, strip=True, strip_comments=True, tags=[])
+            replacement_tag = soup.new_tag('h3')
+            replacement_tag.string = text
+
+            data.replace_with(replacement_tag)
+        else:
+            pass
+
+    if soup.body:
+        contents = ''.join(str(child) for child in soup.body.children)
+    else:
+        print(pkg_dict['id'])
+        contents = ''
+
+    return contents
 
 def sanitise_markup_for_search_results(html: str) -> str:
     """
-    Sanitise and fix markup in HTML strings for search result context    
+    Sanitise and fix markup in HTML strings for search result context
     """
     soup = BeautifulSoup(html, "lxml")
 
@@ -147,11 +234,10 @@ def sanitise_markup_for_search_results(html: str) -> str:
     # Bleach sanitises HTML string by removing unsafe tags and attributes.
     # It also removes mismatched tags.
     # NOTE: CSS in style arrtibutes isn't sanitised but can be added through additional dependencies,
-    # see bleach.CSS_SANITIZER.    
+    # see bleach.CSS_SANITIZER.
     return bleach.clean(" ".join(soup.stripped_strings), strip=True)
 
     return str(soup)
-
 
 def _sanitise_markup(html: str, remove_tags: bool = True) -> str:
     soup = BeautifulSoup(html, "lxml")
@@ -213,7 +299,7 @@ def orgs_list_for_user(user: str, permission: str = 'read') -> list[dict[str, An
     '''
     context: Context = {'user': user}
     data_dict = { 'permission': permission}
-    orgs = logic.get_action('organization_list_for_user')(context, data_dict)    
+    orgs = logic.get_action('organization_list_for_user')(context, data_dict)
     return orgs
 
 def is_sysadmin():
@@ -221,7 +307,7 @@ def is_sysadmin():
         return True
     else:
         return False
-    
+
 def get_helpers():
     return {
         "get_followed_datasets": followed,

--- a/ckanext/gla/helpers.py
+++ b/ckanext/gla/helpers.py
@@ -1,5 +1,6 @@
 import os
 import re
+import logging
 from typing import Any
 
 import bleach
@@ -22,6 +23,7 @@ from ckan.lib.helpers import render_markdown as original_render_markdown
 
 site_title = config.get("ckan.site_title", "Default Site Title")
 
+log = logging.getLogger(__name__)
 
 def __page_context(request):
     page_info = {"source": "", "is_search": False}
@@ -146,9 +148,8 @@ allow_listed_tag_attrs = {
         'tbody': [],
         'tfoot': [],
         'caption': [],
-        'div':[],  # TODO consider
+        'div':[], 
         'img': ['alt','src'],
-        'iframe': ['src'],
         'iframe':['src'],
         'p':['class'] # Temporarily allowed but post filter later for specific classes only e.g. dfl_trusted_email_access
 }
@@ -177,34 +178,54 @@ def sanitise_markup_for_dataset_page(html: str, pkg_dict: dict[str, Any]) -> str
                         protocols=ALLOWED_PROTOCOLS)
 
     soup = BeautifulSoup(html, "lxml")
-
+    
     for data in soup(allow_listed_tag_attrs.keys()):
-        # If the tag is in the whitelist, filter its attributes
+        if data.name == 'table':
+            # No changes necessary
+            # log.debug(f'Table on dataset %s' % pkg_dict.get('name'))
+            pass
         if data.name == 'iframe':
-            print(f'Replacing iframe data URLs %s' % pkg_dict.get('name'))
+            log.debug(f'Replacing iframe %s' % pkg_dict.get('name'))
             # Replace iframe with a link
             iframe_src = data.get('src', '#')
-            replacement_tag= soup.new_tag("p")
-            replacement_tag.string = "This description contains embedded content "
+            replacement_tag= soup.new_tag("p", **{'class': 'dfl_replaced_content'})
+            replacement_tag.string = "Embedded content has been removed from this description ("
 
             # Create <a> tag with href attribute
             a_tag = soup.new_tag("a", href=iframe_src)
-            a_tag.string = "that can be viewed here"
+            a_tag.string = "view here"
             replacement_tag.append(a_tag)
-            replacement_tag.append('.')
+            replacement_tag.append(')')
 
             data.replace_with(replacement_tag)
-        elif data.name == 'img' and data.get('src','').startswith('data:'):
-            print(f'Replacing img data URLs %s' % pkg_dict.get('name'))
-            replacement_tag = soup.new_tag('p', **{'class': 'dfl_replaced_image'})
-            replacement_tag.append("[an embedded image cannot be displayed here - ")
+        elif data.name == 'img': 
+            log.debug(f'Replacing img with alt text (if any) %s' % pkg_dict.get('name'))
+            #print(data)
+            replacement_tag = soup.new_tag('p', **{'class': 'dfl_replaced_content'})
+            
+            if data.get('alt'):
+               replacement_tag.append(f'An image 〝')
+               em_tag = soup.new_tag('em', **{'class': 'replaced_image_description'})
+               em_tag.string = data.get('alt')
+    
+               replacement_tag.append(em_tag)
+               replacement_tag.append('〞 has been removed from this description (')
+    
+            else:                
+                replacement_tag.append("An image has been removed from this description (")
+            
+            for parent in data.find_parents('a'):
+                parent.unwrap()
+                
             a_tag = soup.new_tag('a', href=pkg_dict['upstream_url'])
-            a_tag.string = 'view on source site'
+            a_tag.string = 'view upstream'
             replacement_tag.append(a_tag)
-            replacement_tag.append(']')
+            replacement_tag.append(")")
+                
             data.replace_with(replacement_tag)
+            
         elif data.name in ['h1','h2','h3','h4','h5','h6','h7']:
-            print(f'Replacing heading with consistent one')
+            log.debug(f'Replacing heading with consistent one')
             text = ''.join(str(child) for child in data.children)
             text = bleach.clean(text, strip=True, strip_comments=True, tags=[])
             replacement_tag = soup.new_tag('h3')
@@ -217,7 +238,6 @@ def sanitise_markup_for_dataset_page(html: str, pkg_dict: dict[str, Any]) -> str
     if soup.body:
         contents = ''.join(str(child) for child in soup.body.children)
     else:
-        print(pkg_dict['id'])
         contents = ''
 
     return contents

--- a/ckanext/gla/helpers.py
+++ b/ckanext/gla/helpers.py
@@ -124,12 +124,20 @@ def get_site_title(request):
         return None
 
 
-def sanitise_markup(html: str, remove_tags: bool = True) -> str:
+def sanitise_markup_for_dataset_page(html: str, pkg_dict) -> str:
     """
     Sanitise and fix markup in HTML strings.
+    """
+    soup = BeautifulSoup(html, "lxml")
 
-    :param remove_tags: If True then remove all html tags from the string and only return the text.
-    If False, keep all tags in bleach's ALLOWED_TAGS list and attributes in ALLOWED_ATTRIBUTES list.
+    for data in soup(["style", "script", "iframe", "br"]):
+        data.decompose()
+
+    return str(soup)
+
+def sanitise_markup_for_search_results(html: str) -> str:
+    """
+    Sanitise and fix markup in HTML strings for search result context    
     """
     soup = BeautifulSoup(html, "lxml")
 
@@ -139,9 +147,8 @@ def sanitise_markup(html: str, remove_tags: bool = True) -> str:
     # Bleach sanitises HTML string by removing unsafe tags and attributes.
     # It also removes mismatched tags.
     # NOTE: CSS in style arrtibutes isn't sanitised but can be added through additional dependencies,
-    # see bleach.CSS_SANITIZER.
-    if remove_tags:
-        return bleach.clean(" ".join(soup.stripped_strings), strip=True)
+    # see bleach.CSS_SANITIZER.    
+    return bleach.clean(" ".join(soup.stripped_strings), strip=True)
 
     return str(soup)
 

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -376,10 +376,10 @@ class GlaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, DefaultPerm
         timestamps.set_to_now(ctx, resources)
 
     def before_dataset_index(self, pkg_dict: dict[str, Any]) -> dict[str, Any]:
-        pkg_dict["notes_with_markup"] = helpers.sanitise_markup(
-            pkg_dict["notes"], remove_tags=False
+        pkg_dict["notes_with_markup"] = helpers.sanitise_markup_for_dataset_page(
+            pkg_dict["notes"], pkg_dict
         )
-        pkg_dict["notes"] = helpers.sanitise_markup(pkg_dict["notes"], remove_tags=True)
+        pkg_dict["notes"] = helpers.sanitise_markup_for_search_results(pkg_dict["notes"])
 
         validated_data_dict = json.loads(pkg_dict.get("validated_data_dict", {}))
         validated_data_dict["notes"] = pkg_dict["notes"]

--- a/ckanext/gla/plugin.py
+++ b/ckanext/gla/plugin.py
@@ -32,9 +32,9 @@ from .login import ( login )
 
 from flask import has_request_context
 
-TABLE_FORMATS = toolkit.config.get("ckan.harvesters.table_formats").split(" ")
-REPORT_FORMATS = toolkit.config.get("ckan.harvesters.report_formats").split(" ")
-GEOSPATIAL_FORMATS = toolkit.config.get("ckan.harvesters.geospatial_formats").split(" ")
+TABLE_FORMATS = toolkit.config.get("ckan.harvesters.table_formats","csv xls xlsx xlsm tsv spreadsheet tab google-sheet").split(" ")
+REPORT_FORMATS = toolkit.config.get("ckan.harvesters.report_formats","zip html htm pdf docx doc odw").split(" ")
+GEOSPATIAL_FORMATS = toolkit.config.get("ckan.harvesters.geospatial_formats","geojson shp mbtiles kml").split(" ")
 
 def load_config_as_list(key):
     val = toolkit.config.get(key,'')

--- a/ckanext/gla/public/gla.css
+++ b/ckanext/gla/public/gla.css
@@ -299,6 +299,14 @@ small {
     text-decoration: none;
 }
 
+p.dfl_replaced_content {
+    border-color: red;
+    border: 1px;
+    border-style: dashed;
+    padding: 0.5em;
+    font-style: italic;
+}
+
 .btn:focus,
 .btn:hover,
 .btn-default:focus,

--- a/ckanext/gla/tests/test_plugin.py
+++ b/ckanext/gla/tests/test_plugin.py
@@ -64,7 +64,14 @@ def dsp_sanitise(html_str):
     return h.sanitise_markup_for_dataset_page(html_str, pkg_dict)
 
 def test_dataset_page_html_sanitisation():
-    # TODO
+
+    # NOTE we attempt to implement the main ideas in this spec:
+    #
+    # https://london.atlassian.net/wiki/spaces/DAT/pages/4292673544/Ingestion+Rendering
+    #
+    # Though there are also additional measures we implement, e.g.
+    # allowing headings but normalising them all to h3.
+    
     assert '<h3>heading</h3>' == dsp_sanitise('<html><body><h1>heading</h1></body></html>')    
     assert '<h3>heading</h3>' == dsp_sanitise('<html><body><h1>heading</h1></body></html>')
     assert '<h3>heading</h3>' == dsp_sanitise('<html><body><h3>heading</h3></body></html>')
@@ -77,14 +84,28 @@ def test_dataset_page_html_sanitisation():
 
     assert '<h3>heading text</h3>' == dsp_sanitise('<html><body><h2><strong>heading text</strong></h2></body></html>')
 
+    # Test replacing inlined data urls
+    assert '<p>blah blah blah</p><p class="dfl_replaced_content">An image has been removed from this description (<a href="http://upstream/url">view upstream</a>)</p>' == dsp_sanitise('<p>blah blah blah</p><img src="data:encoded_img_contents"/>')
 
-    assert '<p>blah blah blah</p><p class="dfl_replaced_image">[an embedded image cannot be displayed here - <a href="http://upstream/url">view on source site</a>]</p>' == dsp_sanitise('<p>blah blah blah</p><img src="data:encoded_img_contents"/>')    
-    
-    # assert '<html><body><h2>heading</h2></body></html>' == \
-    # h.sanitise_markup('<html><body><h2>heading</h2></body></html>', remove_tags=False)
+    assert '<p>Style tags should be replaced wherever they are</p>' == dsp_sanitise('<p style="color: blue;">Style tags should be replaced wherever they are</p>')
+    assert '<p>Style tags should be replaced <em>wherever</em> they are</p>' == dsp_sanitise('<p>Style tags should be replaced <em style="color: red;">wherever</em> they are</p>')
 
-    # assert 'heading other text here' == h.sanitise_markup('<html><body><h2>heading</h2><p>other text here</p></body></html>',
-    #                                                       {'name':'my-dataset','upstream_url':'http://upstream/url'})
+    # Test replacing iframes with links
+    assert '<p>blah blah blah: <p class="dfl_replaced_content">Embedded content has been removed from this description (<a href="http://example.org/">view here</a>)</p></p>' == dsp_sanitise('<p>blah blah blah: <iframe src="http://example.org/"/></p>')
 
-    # assert 'heading' == h.sanitise_markup('<p>Leave this paragraph intact!</p><p>And this one too!</p>',
-    #                                {'name':'my-dataset','upstream_url':'http://upstream/url'})
+
+    assert '<p class="dfl_replaced_content">An image 〝<em class="replaced_image_description">Example Image</em>〞 has been removed from this description (<a href="http://upstream/url">view upstream</a>)</p>' == dsp_sanitise('<img alt="Example Image" src="http://example.org/external-img.png"/>')
+
+    # handle special case of images surrounded by parent anchor tags
+    assert '<p class="dfl_replaced_content">An image 〝<em class="replaced_image_description">Example Image</em>〞 has been removed from this description (<a href="http://upstream/url">view upstream</a>)</p>' == dsp_sanitise('<a href="http://parent.link/"><img alt="Example Image" src="http://example.org/external-img.png"/></a>')
+
+    assert '<ul><li>one</li><li>two</li></ul>' == dsp_sanitise('<ul><li>one</li><li>two</li></ul>')
+    assert '<ol><li>one</li><li>two</li></ol>' == dsp_sanitise('<ol><li>one</li><li>two</li></ol>')
+    assert '<strong>strong text</strong>' == dsp_sanitise('<strong>strong text</strong>')
+
+    assert '<table><tbody><tr><th>Header</th><th>Header 2</th></tr><tr><td>Cell 1</td><td>Cell 2</td></tr></tbody></table>' == dsp_sanitise('<table><tr><th>Header</th><th>Header 2</th></tr><tr><td>Cell 1</td><td>Cell 2</td></tr></table>')
+    assert '<table><caption>Table Caption</caption><tbody><tr><td>Cell</td></tr></tbody></table>' == dsp_sanitise('<table><caption>Table Caption</caption><tr><td>Cell</td></tr></table>')
+
+    assert '<table><thead><tr><th>Header</th></tr></thead><tbody><tr><td>Body cell</td></tr></tbody><tfoot><tr><td>Footer cell</td></tr></tfoot></table>' == dsp_sanitise('<table><thead><tr><th>Header</th></tr></thead><tbody><tr><td>Body cell</td></tr></tbody><tfoot><tr><td>Footer cell</td></tr></tfoot></table>')
+
+

--- a/ckanext/gla/tests/test_plugin.py
+++ b/ckanext/gla/tests/test_plugin.py
@@ -1,5 +1,4 @@
-"""
-Tests for plugin.py.
+"""Tests for plugin.py.
 
 Tests are written using the pytest library (https://docs.pytest.org), and you
 should read the testing guidelines in the CKAN docs:
@@ -48,9 +47,44 @@ To temporary patch the CKAN configuration for the duration of a test you can use
         pass
 """
 import ckanext.gla.plugin as plugin
-
+import pytest
+import ckan.plugins as p
 
 @pytest.mark.ckan_config("ckan.plugins", "gla")
 @pytest.mark.usefixtures("with_plugins")
 def test_plugin():
-    assert plugin_loaded("gla")
+    assert p.plugin_loaded("gla")
+
+import ckanext.gla.helpers as h
+
+# dataset page sanitisation wrapper that simulates the pkg_dict info
+# we expect.
+def dsp_sanitise(html_str):
+    pkg_dict = {'name':'my-dataset','upstream_url':'http://upstream/url'}
+    return h.sanitise_markup_for_dataset_page(html_str, pkg_dict)
+
+def test_dataset_page_html_sanitisation():
+    # TODO
+    assert '<h3>heading</h3>' == dsp_sanitise('<html><body><h1>heading</h1></body></html>')    
+    assert '<h3>heading</h3>' == dsp_sanitise('<html><body><h1>heading</h1></body></html>')
+    assert '<h3>heading</h3>' == dsp_sanitise('<html><body><h3>heading</h3></body></html>')
+    assert '<h3>heading</h3>' == dsp_sanitise('<html><body><h4>heading</h4></body></html>')
+    assert '<h3>heading</h3>' == dsp_sanitise('<html><body><h5>heading</h5></body></html>')
+    assert '<h3>heading</h3>' == dsp_sanitise('<html><body><h6>heading</h6></body></html>')
+    assert '<h3>heading</h3>' == dsp_sanitise('<html><body><h7>heading</h7></body></html>')
+    # no such thing as h8
+    assert '<p>heading</p>' == dsp_sanitise('<html><body><h8>heading</h8></body></html>')
+
+    assert '<h3>heading text</h3>' == dsp_sanitise('<html><body><h2><strong>heading text</strong></h2></body></html>')
+
+
+    assert '<p>blah blah blah</p><p class="dfl_replaced_image">[an embedded image cannot be displayed here - <a href="http://upstream/url">view on source site</a>]</p>' == dsp_sanitise('<p>blah blah blah</p><img src="data:encoded_img_contents"/>')    
+    
+    # assert '<html><body><h2>heading</h2></body></html>' == \
+    # h.sanitise_markup('<html><body><h2>heading</h2></body></html>', remove_tags=False)
+
+    # assert 'heading other text here' == h.sanitise_markup('<html><body><h2>heading</h2><p>other text here</p></body></html>',
+    #                                                       {'name':'my-dataset','upstream_url':'http://upstream/url'})
+
+    # assert 'heading' == h.sanitise_markup('<p>Leave this paragraph intact!</p><p>And this one too!</p>',
+    #                                {'name':'my-dataset','upstream_url':'http://upstream/url'})


### PR DESCRIPTION
Implement [DAT-752](https://london.atlassian.net/browse/DAT-752) to allow only a subset of  HTML tags, and to rewrite some of that subset into a more uniform presentation for DFL.

We implement the agreed [specification](https://london.atlassian.net/wiki/spaces/DAT/pages/4292673544/Ingestion+Rendering) with some other extensions, e.g. harmonising headings that are at levels outside our information heading/hierarchy into `h3`'s.

Unit tests provide examples of the main cases covered; these can be run from the top level repository with 

`$ just pytest`

These changes do not require re running the harvesters; they can be applied by just rebuilding the search index with the command: 

```
$ docker exec ckan ckan search-index rebuild --clear
```