### PR TITLE
Resolve DAT-854 by commenting out dataset activity tab from the UI

### DIFF
--- a/ckanext/gla/templates/package/read_base.html
+++ b/ckanext/gla/templates/package/read_base.html
@@ -2,5 +2,13 @@
 
 {% block content_primary_nav %}
 {{ h.build_nav_icon(dataset_type ~ '.read', _('Dataset'),  id=pkg.name, icon='sitemap') }}
+
+{#
+Commented out activity stream because modified times are not reliable.
+This is a workaround to https://london.atlassian.net/browse/DAT-854
+#}
+
+{#
 {{ h.build_nav_icon('activity.package_activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name, icon='clock') }}
+#}
 {% endblock %}

--- a/ckanext/gla/templates/snippets/activities/changed_package.html
+++ b/ckanext/gla/templates/snippets/activities/changed_package.html
@@ -1,0 +1,1 @@
+{# Delete this file to restore activity stream feature on packages/datasets. #}

--- a/ckanext/gla/templates/snippets/activities/changed_resource.html
+++ b/ckanext/gla/templates/snippets/activities/changed_resource.html
@@ -1,0 +1,2 @@
+changed resource
+{# Delete this file to restore activity stream feature on packages/datasets. #}


### PR DESCRIPTION
Removes the tab for the timeline view for each dataset; and also removes reporting of package and resource level updates from the activity stream view.  This effectively removes the links to these pages.

Instructions on how to re-enable this behaviour are in the commits.