### PR TITLE
DAT-869: Accessibility fixes to forms around required fields

### DIFF
--- a/ckanext/gla/templates/macros/form/input_block.html
+++ b/ckanext/gla/templates/macros/form/input_block.html
@@ -1,0 +1,32 @@
+{#
+A generic input_block for providing the default markup for CKAN form elements.
+It is expected to be called using a {% call %} block, the contents of which
+will be inserted into the .controls element.
+
+for     - The id for the input that the label should match.
+label   - A human readable label.
+error   - A list of error strings for the field or just true.
+classes - An array of custom classes for the outer element.
+control_classes - An array of custom classes for the .control wrapper.
+extra_html - An html string to be inserted after the errors eg. info text.
+is_required - Boolean of whether this input is requred for the form to validate
+
+Example:
+
+{% import 'macros/form.html' as form %}
+{% call form.input_block("field", "My Field") %}
+<input id="field" type="text" name="{{ name }}" value="{{ value | empty_and_escape }}" />
+{% endcall %}
+
+#}
+
+{% macro input_block(for, label="", error="", classes=[], control_classes=[], extra_html="", is_required=false) %}
+<div class="form-group{{ " error" if error }}{{ " " ~ classes | join(' ') }}">
+<label class="form-label" for="{{ for }}">{% if is_required %}<span title="{{ _("This field is required") }}" class="control-required">*</span> {% endif %}{{ label or _('Custom') }}</label>
+<div class="controls{{ " " ~ control_classes | join(' ') }}">
+{{ caller() }}
+{% if error and error is iterable %}<span class="error-block">{{ error|join(', ') }}</span>{% endif %}
+{{ extra_html }}
+</div>
+</div>
+{% endmacro %}

--- a/ckanext/gla/templates/macros/form/input_block.html
+++ b/ckanext/gla/templates/macros/form/input_block.html
@@ -22,7 +22,7 @@ Example:
 
 {% macro input_block(for, label="", error="", classes=[], control_classes=[], extra_html="", is_required=false) %}
 <div class="form-group{{ " error" if error }}{{ " " ~ classes | join(' ') }}">
-<label class="form-label" for="{{ for }}">{% if is_required %}<span title="{{ _("This field is required") }}" class="control-required">*</span> {% endif %}{{ label or _('Custom') }}</label>
+<label class="form-label" for="{{ for }}">{% if is_required %}<span {% if is_required %}aria-hidden="true"{% endif %} class="control-required">*</span> {% endif %}{{ label or _('Custom') }}</label>
 <div class="controls{{ " " ~ control_classes | join(' ') }}">
 {{ caller() }}
 {% if error and error is iterable %}<span class="error-block">{{ error|join(', ') }}</span>{% endif %}

--- a/ckanext/gla/templates/macros/form/required_message.html
+++ b/ckanext/gla/templates/macros/form/required_message.html
@@ -1,0 +1,13 @@
+{#
+Outputs the "* Required field" message for the bottom of formss
+
+Example
+{% import 'macros/form.html' as form %}
+{{ form.required_message() }}
+
+#}
+{% macro required_message() %}
+<p aria-hidden="true" class="control-required-message">
+  <span class="control-required">*</span> {{ _("Required field") }}
+</p>
+{% endmacro %}

--- a/ckanext/gla/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/gla/templates/package/snippets/package_basic_fields.html
@@ -69,7 +69,8 @@
         placeholder=_("boost factor"),
         value=data.dataset_boost,
         error=errors.dataset_boost,
-        classes=["control-medium"])
+        classes=["control-medium"],
+        is_required=true)
 }}
 {{
     form.checkbox("archived",

--- a/ckanext/gla/templates/user/snippets/login_form.html
+++ b/ckanext/gla/templates/user/snippets/login_form.html
@@ -3,13 +3,19 @@
 {% set username_error = true if error_summary %}
 {% set password_error = true if error_summary %}
 
+{% block form %}
 <form action="{{ action }}" method="post">
     {{ h.csrf_input() }}
     {{ form.errors(errors=error_summary) }}
 
-    {{ form.input('login', label=_("Username or Email"), id='field-login', value="", error=username_error, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'username', 'required': 'true'}) }}
+    {% block core_fields %}
+      {% block required_core_fields %}
 
-    {{ form.input('password', label=_("Password"), id='field-password', type="password", value="", error=password_error, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'current-password', 'required': 'true'}) }}
+        {{ form.input('login', label=_("Username or Email"), id='field-login', value="", error=username_error, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'username', 'required': 'true'}, is_required=True) }}
+
+        {{ form.input('password', label=_("Password"), id='field-password', type="password", value="", error=password_error, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'current-password', 'required': 'true'}, is_required=True) }}
+      {% endblock %}
+    {% endblock %}
 
     <div class="form-actions">
         {% block login_button %}
@@ -17,3 +23,4 @@
         {% endblock %}
     </div>
 </form>
+{% endblock %}

--- a/ckanext/gla/templates/user/snippets/login_form.html
+++ b/ckanext/gla/templates/user/snippets/login_form.html
@@ -7,9 +7,9 @@
     {{ h.csrf_input() }}
     {{ form.errors(errors=error_summary) }}
 
-    {{ form.input('login', label=_("Username or Email"), id='field-login', value="", error=username_error, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'username'}) }}
+    {{ form.input('login', label=_("Username or Email"), id='field-login', value="", error=username_error, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'username', 'required': 'true'}) }}
 
-    {{ form.input('password', label=_("Password"), id='field-password', type="password", value="", error=password_error, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'current-password'}) }}
+    {{ form.input('password', label=_("Password"), id='field-password', type="password", value="", error=password_error, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'current-password', 'required': 'true'}) }}
 
     <div class="form-actions">
         {% block login_button %}


### PR DESCRIPTION
- Use `aria-hidden` to hide legend from accessibility tree (as it's unecessary in this context)
- Mark form inputs as `required`, the accessibility consultants suggested `aria-required` but these are all stock browser controls, so `required` should be a better fit
- Use `aria-hidden` over the `*` visually marking required fields as this is now redundant for aria users

Added to the following forms: 

- [X] Login form
- [X] Create account form
- [X] Password reset form
- [X] Dataset page
- [X] Organisation form 