### PR TITLE
Fix GET requests on package_search

### DIFF
--- a/ckanext/gla/search_highlight/action.py
+++ b/ckanext/gla/search_highlight/action.py
@@ -69,6 +69,7 @@ def filtered_facets(all_facets):
     return non_zero_or_selected_facets
 
 
+@toolkit.side_effect_free
 def package_search(context: Context, data_dict: DataDict) -> ActionResult.PackageSearch:
     """
     This is a copy of the original package_search function from ckan.logic.action.get


### PR DESCRIPTION
`package_search` fails on `GET` requests with a "Please use 'POST' method" response due to the absence of the `side_effect_free` decorator:
```
def side_effect_free(action: Decorated) -> Decorated:
    '''A decorator that marks the given action function as side-effect-free.

    Action functions decorated with this decorator can be called with an HTTP
    GET request to the :doc:`Action API </api/index>`. Action functions that
    don't have this decorator must be called with a POST request.

    If your CKAN extension defines its own action functions using the
    :py:class:`~ckan.plugins.interfaces.IActions` plugin interface, you can use
    this decorator to make your actions available with GET requests instead of
    just with POST requests.

    Example::

        import ckan.plugins.toolkit as toolkit

        @toolkit.side_effect_free
        def my_custom_action_function(context, data_dict):
            ...

    (Then implement :py:class:`~ckan.plugins.interfaces.IActions` to register
    your action function with CKAN.)

    '''
    # type_ignore_reason: custom attribute
    action.side_effect_free = True  # type: ignore
    return action
```

Maybe the `package_search` wasn't used as an API call by anyone on the old portal (and all calls to `package_search` were done via code), but the decoupled frontend needs to hit the endpoint, and preferably using `GET` instead of `POST`. This is the only endpoint we've noticed with this issue so far, so I'm only applying here for now.